### PR TITLE
ci: run tests on develop pushes and pull requests

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -2,9 +2,9 @@ name: Run tests and upload coverage
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, develop ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, develop ]
     
 jobs:
   test:


### PR DESCRIPTION
`codecov.yml` triggered only on `main`, so pull requests targeting `develop` ran no build or test check — the run history shows no execution on `develop` at all. Branch protection there had nothing to require beyond CodeQL, which is a security scan rather than a build gate.

Adds `develop` to both trigger lists. The `test` job runs `go test -race ./...`, which compiles every package, so it gates builds as well as tests.

> [!NOTE]
> Once this merges, add the check to branch protection:
> ```
> gh api -X PATCH repos/retail-ai-inc/sync/branches/develop/protection/required_status_checks \
>   -f 'contexts[]=CodeQL' -f 'contexts[]=Run tests and collect coverage'
> ```

