### PR TITLE
fix: bind development databases to loopback and unignore cmd/sync

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,7 +55,7 @@ config.json
 .goreleaser.yaml
 dist/
 
-sync
+/sync
 cloudbuild.yaml
 docker-compose-demo.yml
 sync.db-wal

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -6,6 +6,7 @@ services:
     restart: always
     environment:
       MYSQL_ROOT_PASSWORD: root
+      MYSQL_ROOT_HOST: '%'
       MYSQL_DATABASE: source_db
     volumes:
       - ./resources/mysql/init.sql:/docker-entrypoint-initdb.d/init.sql
@@ -18,6 +19,7 @@ services:
     restart: always
     environment:
       MYSQL_ROOT_PASSWORD: root
+      MYSQL_ROOT_HOST: '%'
       MYSQL_DATABASE: target_db
     ports:
       - "127.0.0.1:3308:3306"
@@ -27,6 +29,7 @@ services:
     restart: always
     environment:
       MARIADB_ROOT_PASSWORD: root
+      MARIADB_ROOT_HOST: '%'
       MARIADB_DATABASE: source_db
     volumes:
       - ./resources/mariadb/init.sql:/docker-entrypoint-initdb.d/init.sql
@@ -39,6 +42,7 @@ services:
     restart: always
     environment:
       MARIADB_ROOT_PASSWORD: root
+      MARIADB_ROOT_HOST: '%'
       MARIADB_DATABASE: target_db
     ports:
       - "127.0.0.1:3309:3306"

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - ./resources/mysql/init.sql:/docker-entrypoint-initdb.d/init.sql
       - ./resources/mysql/mysql_custom.cnf:/etc/mysql/conf.d/mysql_custom.cnf
     ports:
-      - "3306:3306"
+      - "127.0.0.1:3306:3306"
 
   mysql_target:
     image: mysql:8.1
@@ -20,7 +20,7 @@ services:
       MYSQL_ROOT_PASSWORD: root
       MYSQL_DATABASE: target_db
     ports:
-      - "3308:3306"
+      - "127.0.0.1:3308:3306"
 
   mariadb_source:
     image: mariadb:10.6
@@ -32,7 +32,7 @@ services:
       - ./resources/mariadb/init.sql:/docker-entrypoint-initdb.d/init.sql
       - ./resources/mariadb/mariadb_custom.cnf:/etc/mysql/conf.d/mariadb_custom.cnf
     ports:
-      - "3307:3306"
+      - "127.0.0.1:3307:3306"
 
   mariadb_target:
     image: mariadb:10.6
@@ -41,7 +41,7 @@ services:
       MARIADB_ROOT_PASSWORD: root
       MARIADB_DATABASE: target_db
     ports:
-      - "3309:3306"
+      - "127.0.0.1:3309:3306"
 
   postgresql_source:
     image: postgres:15
@@ -52,7 +52,7 @@ services:
       POSTGRES_DB: source_db
       POSTGRES_INITDB_ARGS: "--data-checksums"
     ports:
-      - "5432:5432"
+      - "127.0.0.1:5432:5432"
     volumes:
       - ./resources/postgresql/init.sql:/docker-entrypoint-initdb.d/init.sql
       - ./resources/postgresql/postgresql.conf:/etc/postgresql/postgresql.conf
@@ -67,7 +67,7 @@ services:
       POSTGRES_DB: target_db
       POSTGRES_INITDB_ARGS: "--data-checksums"
     ports:
-      - "5433:5432"
+      - "127.0.0.1:5433:5432"
 
   mongodb_source:
     image: mongo:6.0
@@ -76,13 +76,13 @@ services:
     volumes:
       - ./resources/mongodb/init.js:/docker-entrypoint-initdb.d/init.js:ro
     ports:
-      - "27017:27017"
+      - "127.0.0.1:27017:27017"
 
   mongodb_target:
     image: mongo:6.0
     restart: always
     ports:
-      - "27018:27017"
+      - "127.0.0.1:27018:27017"
 
   redis_source:
     image: redis:7.0
@@ -98,4 +98,4 @@ services:
         wait
       "
     ports:
-      - "6379:6379"
+      - "127.0.0.1:6379:6379"


### PR DESCRIPTION
## Problem

Two unrelated defects in the local development setup, both silent.

**1. Databases published on all interfaces.** Every port in
`docker/docker-compose.yml` was published on `0.0.0.0`, exposing the
containers on the host's public interface with `root`/`root` for MySQL
and MariaDB, `postgres`/`postgres` for PostgreSQL, no password for Redis
and no authentication for MongoDB.

A host firewall does not help: Docker's DNAT rules sit in the `DOCKER`
chain, which packets reach before `INPUT`.

**2. `cmd/sync` was ignored.** The bare `sync` pattern in `.gitignore`
matched the `cmd/sync` directory as well as the compiled binary, so any
file added there was silently dropped. `cmd/sync/main.go` survived only
because it was already tracked.

## Change

1. `fix(docker)` — bind every published port to `127.0.0.1`.
2. `chore(docker)` — set `MYSQL_ROOT_HOST` / `MARIADB_ROOT_HOST` to `%`,
   since tests connect through the published port and so appear to come
   from the Docker bridge gateway rather than localhost. This widens
   root's host restriction and is acceptable only because of commit 1 —
   reverting that binding requires reverting this too.
3. `fix(gitignore)` — anchor the pattern as `/sync`, which leaves the
   binary ignored and makes the directory usable.

No application code is touched.