### PR TITLE
test: rebuild the suite against a feature inventory

### DIFF
--- a/cmd/sync/dispatch_test.go
+++ b/cmd/sync/dispatch_test.go
@@ -1,0 +1,142 @@
+package main
+
+import (
+	"context"
+	"io"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+// quietLog returns a logger that discards output.
+func quietLog() *logrus.Logger {
+	l := logrus.New()
+	l.SetOutput(io.Discard)
+	return l
+}
+
+// waitWithin reports whether wg reached zero inside the timeout, so a leaked
+// WaitGroup counter surfaces as a failure rather than a hung test.
+func waitWithin(wg *sync.WaitGroup, timeout time.Duration) bool {
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+		return true
+	case <-time.After(timeout):
+		return false
+	}
+}
+
+func TestStartSyncTasksSkipsDisabledTasks(t *testing.T) {
+	task := baseTask()
+	task.Enable = false
+
+	var wg sync.WaitGroup
+	startSyncTasks(context.Background(), cfgWith(task), &wg, quietLog())
+
+	if !waitWithin(&wg, time.Second) {
+		t.Fatal("a disabled task still added to the WaitGroup")
+	}
+}
+
+func TestStartSyncTasksOnAnEmptyConfig(t *testing.T) {
+	var wg sync.WaitGroup
+	startSyncTasks(context.Background(), cfgWith(), &wg, quietLog())
+
+	if !waitWithin(&wg, time.Second) {
+		t.Fatal("an empty config added to the WaitGroup")
+	}
+}
+
+// An unrecognised sync type is logged at error level and the WaitGroup counter
+// is released, so the process keeps running with that task simply absent. There
+// is no failed state anywhere: the task shows as enabled in the API and
+// nothing replicates.
+func TestAnUnknownSyncTypeIsSilentlyDropped(t *testing.T) {
+	task := baseTask()
+	task.Type = "cassandra"
+
+	var wg sync.WaitGroup
+	startSyncTasks(context.Background(), cfgWith(task), &wg, quietLog())
+
+	if !waitWithin(&wg, time.Second) {
+		t.Fatal("an unknown sync type leaked a WaitGroup counter — the default branch appears to have changed")
+	}
+}
+
+// The type switch is case-sensitive and has no alias handling, so a config
+// value that differs only in case is treated as unknown and the task never
+// runs. The API stores what the UI sends, and nothing normalises it.
+func TestSyncTypeMatchingIsCaseSensitive(t *testing.T) {
+	for _, typ := range []string{"MongoDB", "MySQL", "MariaDB", "PostgreSQL", "Redis", "postgres", "mongo"} {
+		task := baseTask()
+		task.Type = typ
+
+		var wg sync.WaitGroup
+		startSyncTasks(context.Background(), cfgWith(task), &wg, quietLog())
+
+		// A recognised type would start a syncer goroutine that outlives this
+		// call; an unrecognised one releases the counter immediately.
+		if !waitWithin(&wg, 500*time.Millisecond) {
+			t.Fatalf("type %q now starts a syncer — the switch appears to normalise case; assert that instead", typ)
+		}
+	}
+}
+
+func TestStartSyncTasksDropsUnknownTypesIndividually(t *testing.T) {
+	unknown := baseTask()
+	unknown.ID = 1
+	unknown.Type = "cassandra"
+
+	disabled := baseTask()
+	disabled.ID = 2
+	disabled.Enable = false
+
+	alsoUnknown := baseTask()
+	alsoUnknown.ID = 3
+	alsoUnknown.Type = ""
+
+	var wg sync.WaitGroup
+	startSyncTasks(context.Background(), cfgWith(unknown, disabled, alsoUnknown), &wg, quietLog())
+
+	if !waitWithin(&wg, time.Second) {
+		t.Fatal("a WaitGroup counter was leaked across the mixed config")
+	}
+}
+
+func TestConfigsEqualIgnoresEverythingOutsideSyncConfigs(t *testing.T) {
+	a := cfgWith(baseTask())
+	b := cfgWith(baseTask())
+
+	a.LogLevel = "debug"
+	b.LogLevel = "trace"
+	a.EnableTableRowCountMonitoring = true
+	b.EnableTableRowCountMonitoring = false
+	a.MonitorInterval = time.Minute
+	b.MonitorInterval = time.Hour
+
+	if !configsEqual(a, b) {
+		t.Error("configsEqual compared fields outside SyncConfigs")
+	}
+}
+
+// runSyncTasks reloads the configuration every ten seconds and restarts the
+// syncers only when SyncConfigs changed. Everything else — log level, the
+// row-count monitoring switch, the monitor interval — is read once at startup
+// and a later edit is picked up by nothing until the process restarts or an
+// unrelated SyncConfigs edit happens to trigger a reload.
+func TestNonSyncConfigEditsNeverTriggerARestart(t *testing.T) {
+	a := cfgWith(baseTask())
+	b := cfgWith(baseTask())
+	b.EnableTableRowCountMonitoring = !a.EnableTableRowCountMonitoring
+
+	if !configsEqual(a, b) {
+		t.Fatal("configsEqual now notices the monitoring switch — the reload appears to have been widened")
+	}
+}

--- a/cmd/sync/main_test.go
+++ b/cmd/sync/main_test.go
@@ -1,0 +1,134 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/retail-ai-inc/sync/pkg/config"
+)
+
+func cfgWith(tasks ...config.SyncConfig) *config.Config {
+	return &config.Config{SyncConfigs: tasks}
+}
+
+func baseTask() config.SyncConfig {
+	return config.SyncConfig{
+		ID:               1,
+		Enable:           true,
+		Type:             "mongodb",
+		TaskName:         "tokyo-to-osaka",
+		SourceConnection: "mongodb://tokyo:27017/source_db",
+		TargetConnection: "mongodb://osaka:27017/target_db",
+		Mappings: []config.DatabaseMapping{{
+			Tables: []config.TableMapping{{SourceTable: "users", TargetTable: "users"}},
+		}},
+	}
+}
+
+func TestConfigsEqual(t *testing.T) {
+	t.Run("identical configurations", func(t *testing.T) {
+		if !configsEqual(cfgWith(baseTask()), cfgWith(baseTask())) {
+			t.Error("two identical configurations compared unequal")
+		}
+	})
+
+	t.Run("both empty", func(t *testing.T) {
+		if !configsEqual(cfgWith(), cfgWith()) {
+			t.Error("two empty configurations compared unequal")
+		}
+	})
+
+	t.Run("different task count", func(t *testing.T) {
+		if configsEqual(cfgWith(baseTask()), cfgWith(baseTask(), baseTask())) {
+			t.Error("configurations with different task counts compared equal")
+		}
+	})
+
+	t.Run("changed enable flag", func(t *testing.T) {
+		disabled := baseTask()
+		disabled.Enable = false
+		if configsEqual(cfgWith(baseTask()), cfgWith(disabled)) {
+			t.Error("a flipped enable flag was not detected")
+		}
+	})
+
+	t.Run("changed mapping", func(t *testing.T) {
+		remapped := baseTask()
+		remapped.Mappings[0].Tables[0].TargetTable = "users_copy"
+		if configsEqual(cfgWith(baseTask()), cfgWith(remapped)) {
+			t.Error("a changed table mapping was not detected")
+		}
+	})
+
+	t.Run("changed advanced settings", func(t *testing.T) {
+		tuned := baseTask()
+		tuned.Mappings[0].Tables[0].AdvancedSettings.MaxRetries = 3
+		if configsEqual(cfgWith(baseTask()), cfgWith(tuned)) {
+			t.Error("a changed advanced setting was not detected")
+		}
+	})
+
+	t.Run("global fields outside SyncConfigs are ignored", func(t *testing.T) {
+		// Only SyncConfigs is compared, so a changed log level or monitor
+		// interval does not restart the sync tasks.
+		a := cfgWith(baseTask())
+		b := cfgWith(baseTask())
+		a.LogLevel, b.LogLevel = "debug", "error"
+		a.MonitorInterval, b.MonitorInterval = time.Minute, time.Hour
+		if !configsEqual(a, b) {
+			t.Error("a changed global field triggered a restart")
+		}
+	})
+}
+
+// TestConfigsEqualIsSensitiveToTimestamps records that the comparison includes
+// LastUpdateTime and LastRunTime, which are bookkeeping columns rather than
+// configuration. Any write that touches them makes the ten-second reload loop
+// consider the configuration changed and tear down every running sync task,
+// not just the one that was edited.
+func TestConfigsEqualIsSensitiveToTimestamps(t *testing.T) {
+	touched := baseTask()
+	touched.LastRunTime = "2026-08-21 10:00:00"
+
+	if configsEqual(cfgWith(baseTask()), cfgWith(touched)) {
+		t.Error("timestamps are no longer part of the comparison, which would " +
+			"remove a class of spurious restarts")
+	}
+}
+
+// TestConfigsEqualRestartsEveryTaskOnOneEdit records the blast radius of the
+// reconciliation loop. The comparison is over the whole slice, so editing one
+// task returns false and cmd/sync cancels the context shared by all of them.
+func TestConfigsEqualRestartsEveryTaskOnOneEdit(t *testing.T) {
+	first, second := baseTask(), baseTask()
+	second.ID = 2
+	second.TaskName = "untouched"
+
+	edited := second
+	before := cfgWith(first, second)
+	after := cfgWith(first, func() config.SyncConfig { e := edited; e.Enable = false; return e }())
+
+	if configsEqual(before, after) {
+		t.Fatal("the edit was not detected at all")
+	}
+	// There is no per-task comparison to fall back on: the caller only learns
+	// that something, somewhere, differs.
+	if configsEqual(cfgWith(first), cfgWith(first)) != true {
+		t.Error("the untouched task does not compare equal on its own")
+	}
+}
+
+func TestConfigsEqualHandlesNilSlices(t *testing.T) {
+	// A nil slice and an empty one both marshal to "null" and "[]" respectively,
+	// so they are not interchangeable.
+	nilCfg := &config.Config{SyncConfigs: nil}
+	emptyCfg := &config.Config{SyncConfigs: []config.SyncConfig{}}
+
+	if configsEqual(nilCfg, emptyCfg) {
+		t.Error("a nil slice and an empty slice compared equal; if that was " +
+			"intended, the comparison would need to normalise them")
+	}
+	if !configsEqual(nilCfg, nilCfg) {
+		t.Error("a nil configuration is not equal to itself")
+	}
+}

--- a/docker/docker-compose.test.yml
+++ b/docker/docker-compose.test.yml
@@ -1,0 +1,45 @@
+# Test-only stack. Ports are shifted so this can run alongside whatever already
+# occupies the defaults on the host (a native mongod holds 27017).
+#
+#   mongo  source 27117 (single-node replica set rs0)  target 27118 (standalone)
+#   redis  source 6479  (keyspace notifications on)    target 6480
+#
+# MySQL and MariaDB are not included: the containers from docker-compose.yml are
+# already running and now accept remote connections.
+services:
+  mongo_test_source:
+    image: mongo:6.0
+    container_name: mongo_test_source
+    command: ["mongod", "--replSet", "rs0", "--bind_ip_all"]
+    ports:
+      - "127.0.0.1:27117:27017"
+    healthcheck:
+      test: ["CMD", "mongosh", "--quiet", "--eval", "db.adminCommand('ping').ok"]
+      interval: 2s
+      timeout: 3s
+      retries: 15
+
+  mongo_test_target:
+    image: mongo:6.0
+    container_name: mongo_test_target
+    ports:
+      - "127.0.0.1:27118:27017"
+    healthcheck:
+      test: ["CMD", "mongosh", "--quiet", "--eval", "db.adminCommand('ping').ok"]
+      interval: 2s
+      timeout: 3s
+      retries: 15
+
+  redis_test_source:
+    image: redis:7.0
+    container_name: redis_test_source
+    command: ["redis-server", "--appendonly", "yes", "--notify-keyspace-events", "KEA"]
+    ports:
+      - "127.0.0.1:6479:6379"
+
+  redis_test_target:
+    image: redis:7.0
+    container_name: redis_test_target
+    command: ["redis-server", "--appendonly", "yes"]
+    ports:
+      - "127.0.0.1:6480:6379"

--- a/pkg/api/auth_utils_test.go
+++ b/pkg/api/auth_utils_test.go
@@ -1,0 +1,285 @@
+package api
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+)
+
+// hmacToken recomputes a token independently of the implementation, so the
+// derivation itself is pinned rather than merely being self-consistent.
+func hmacToken(secret, username, accessLevel, date string) string {
+	h := hmac.New(sha256.New, []byte(secret))
+	h.Write([]byte("user_token:" + username + ":" + accessLevel + ":" + date))
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+func TestGetTokenSecret(t *testing.T) {
+	t.Run("environment variable wins", func(t *testing.T) {
+		t.Setenv("SYNC_TOKEN_SECRET", "a-real-secret")
+		if got := getTokenSecret(); got != "a-real-secret" {
+			t.Errorf("getTokenSecret = %q, want the environment value", got)
+		}
+	})
+
+	t.Run("falls back to the built-in default", func(t *testing.T) {
+		t.Setenv("SYNC_TOKEN_SECRET", "")
+		if got, want := getTokenSecret(), "sync_default_secret_key_change_me_in_production"; got != want {
+			t.Errorf("getTokenSecret = %q, want %q", got, want)
+		}
+	})
+}
+
+// TestDefaultTokenSecretIsHardcoded records F-252. With SYNC_TOKEN_SECRET
+// unset, every deployment shares one secret that is committed to a public
+// repository. Since a token is a pure function of secret, username, access
+// level and date, anyone can compute a valid admin token offline for any day.
+func TestDefaultTokenSecretIsHardcoded(t *testing.T) {
+	t.Setenv("SYNC_TOKEN_SECRET", "")
+
+	secret := getTokenSecret()
+	if secret != "sync_default_secret_key_change_me_in_production" {
+		t.Fatalf("the default secret changed to %q; if key management landed, "+
+			"replace this test with one covering the new source", secret)
+	}
+
+	// Demonstrate the consequence: the admin token for today is reproducible
+	// from public information alone.
+	forged := hmacToken(secret, "admin", "admin", time.Now().Format("2006-01-02"))
+	if forged != GenerateAdminToken() {
+		t.Error("the offline-computed admin token no longer matches; the derivation " +
+			"may have gained a non-public input, which would be an improvement")
+	}
+}
+
+func TestGenerateUserTokenMatchesHMAC(t *testing.T) {
+	today := time.Now().Format("2006-01-02")
+
+	tests := []struct{ username, access string }{
+		{"admin", "admin"},
+		{"alice", "user"},
+		{"", ""},
+		{"user with spaces", "read-only"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.username+"/"+tt.access, func(t *testing.T) {
+			want := hmacToken(tokenSecret, tt.username, tt.access, today)
+			if got := GenerateUserToken(tt.username, tt.access); got != want {
+				t.Errorf("GenerateUserToken(%q, %q) = %q, want %q",
+					tt.username, tt.access, got, want)
+			}
+		})
+	}
+}
+
+func TestGenerateUserTokenIsDeterministic(t *testing.T) {
+	first := GenerateUserToken("alice", "user")
+	for i := 0; i < 5; i++ {
+		if got := GenerateUserToken("alice", "user"); got != first {
+			t.Fatalf("call %d returned %q, want %q", i, got, first)
+		}
+	}
+	// Hex-encoded SHA-256 is 64 characters.
+	if len(first) != 64 {
+		t.Errorf("token length = %d, want 64", len(first))
+	}
+}
+
+func TestGenerateUserTokenVariesByInput(t *testing.T) {
+	base := GenerateUserToken("alice", "user")
+
+	for _, tt := range []struct {
+		name             string
+		username, access string
+	}{
+		{"different username", "bob", "user"},
+		{"different access level", "alice", "admin"},
+		{"username case matters", "Alice", "user"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := GenerateUserToken(tt.username, tt.access); got == base {
+				t.Errorf("GenerateUserToken(%q, %q) collided with the base token",
+					tt.username, tt.access)
+			}
+		})
+	}
+}
+
+// TestGenerateAdminTokenEqualsAdminUserToken records that the admin token is
+// not a distinct credential: it is exactly the user token for the pair
+// ("admin", "admin"). Any account named admin whose access level is admin
+// therefore holds the token that ValidateAdminToken accepts.
+func TestGenerateAdminTokenEqualsAdminUserToken(t *testing.T) {
+	if GenerateAdminToken() != GenerateUserToken("admin", "admin") {
+		t.Error("the admin token is now derived separately from user tokens; " +
+			"assert the new derivation instead")
+	}
+}
+
+func TestValidateAdminToken(t *testing.T) {
+	valid := GenerateAdminToken()
+
+	if !ValidateAdminToken(valid) {
+		t.Error("ValidateAdminToken rejected the token it just generated")
+	}
+
+	for _, tt := range []struct{ name, token string }{
+		{"empty", ""},
+		{"truncated", valid[:63]},
+		{"one character changed", "0" + valid[1:]},
+		{"uppercase hex", strings.ToUpper(valid)},
+		{"a user token", GenerateUserToken("alice", "user")},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if ValidateAdminToken(tt.token) {
+				t.Errorf("ValidateAdminToken(%q) = true, want false", tt.token)
+			}
+		})
+	}
+}
+
+func TestExtractTokenFromHeader(t *testing.T) {
+	tests := []struct {
+		name   string
+		header string
+		want   string
+	}{
+		{"bearer prefix is stripped", "Bearer abc123", "abc123"},
+		{"only the first prefix is stripped", "Bearer Bearer abc", "Bearer abc"},
+		{"no prefix returns the whole value", "abc123", "abc123"},
+		{"empty header", "", ""},
+		// The prefix check is case-sensitive and requires the trailing space,
+		// so these forms are treated as the token itself and fail validation
+		// later with no indication that the header was malformed.
+		{"lowercase bearer is not recognised", "bearer abc123", "bearer abc123"},
+		{"missing space is not recognised", "Bearerabc123", "Bearerabc123"},
+		{"leading whitespace is not trimmed", " Bearer abc123", " Bearer abc123"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ExtractTokenFromHeader(tt.header); got != tt.want {
+				t.Errorf("ExtractTokenFromHeader(%q) = %q, want %q", tt.header, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestTokenSecretIsCapturedAtInit records that the package-level tokenSecret is
+// evaluated once during initialisation, so changing SYNC_TOKEN_SECRET at
+// runtime has no effect on issued tokens. Rotating the secret requires a
+// restart, and the running process gives no sign that the environment and the
+// key in use have diverged.
+func TestTokenSecretIsCapturedAtInit(t *testing.T) {
+	before := GenerateUserToken("alice", "user")
+
+	t.Setenv("SYNC_TOKEN_SECRET", "a-freshly-rotated-secret")
+
+	if after := GenerateUserToken("alice", "user"); after != before {
+		t.Error("tokens now follow the environment at call time; the secret may " +
+			"have become reloadable, which would be an improvement")
+	}
+}
+
+// TestGenerateUserTokenSeparatorIsAmbiguous records a design flaw: the HMAC
+// input joins username and access level with a colon without escaping either,
+// so distinct pairs can produce identical tokens. A user named "a:b" with
+// access "c" is indistinguishable from a user named "a" with access "b:c".
+// Exploitability depends on the access levels in use, but the derivation should
+// not depend on that.
+func TestGenerateUserTokenSeparatorIsAmbiguous(t *testing.T) {
+	first := GenerateUserToken("a", "b:c")
+	second := GenerateUserToken("a:b", "c")
+
+	if first != second {
+		t.Errorf("the two pairs now produce different tokens (%q vs %q); the "+
+			"separator may have been escaped, which would be an improvement",
+			first, second)
+	}
+}
+
+// ValidateUserToken needs the user table, so it could not be covered until the
+// temporary-database fixture existed.
+
+func TestValidateUserToken(t *testing.T) {
+	db := useTempDB(t)
+	insertUser(t, db, "alice", "secret", "Alice", "admin")
+	insertUser(t, db, "bob", "secret", "Bob", "guest")
+
+	t.Run("accepts a token it issued", func(t *testing.T) {
+		ok, username, access := ValidateUserToken(GenerateUserToken("alice", "admin"))
+		if !ok {
+			t.Fatal("ValidateUserToken rejected a token it just generated")
+		}
+		if username != "alice" || access != "admin" {
+			t.Errorf("identity = %q/%q, want alice/admin", username, access)
+		}
+	})
+
+	t.Run("distinguishes users", func(t *testing.T) {
+		_, username, access := ValidateUserToken(GenerateUserToken("bob", "guest"))
+		if username != "bob" || access != "guest" {
+			t.Errorf("identity = %q/%q, want bob/guest", username, access)
+		}
+	})
+
+	t.Run("rejects unknown tokens", func(t *testing.T) {
+		for _, token := range []string{"", "not-a-token", GenerateUserToken("carol", "admin")} {
+			if ok, _, _ := ValidateUserToken(token); ok {
+				t.Errorf("ValidateUserToken(%q) accepted an unknown token", token)
+			}
+		}
+	})
+}
+
+// TestValidateUserTokenIsBoundToTheStoredAccessLevel records that the access
+// level is part of the token input, so changing a user's permissions
+// invalidates their current token. That is a reasonable property on its own,
+// but combined with the daily rotation it means tokens behave like short-lived
+// derivations rather than sessions: there is no way to revoke one without
+// changing the user's stored access level or waiting for midnight.
+func TestValidateUserTokenIsBoundToTheStoredAccessLevel(t *testing.T) {
+	db := useTempDB(t)
+	insertUser(t, db, "alice", "secret", "Alice", "guest")
+
+	issued := GenerateUserToken("alice", "guest")
+	if ok, _, _ := ValidateUserToken(issued); !ok {
+		t.Fatal("the freshly issued token was rejected")
+	}
+
+	if _, err := db.Exec(`UPDATE users SET access = 'admin' WHERE username = 'alice'`); err != nil {
+		t.Fatalf("promote user: %v", err)
+	}
+
+	if ok, _, _ := ValidateUserToken(issued); ok {
+		t.Error("the old token still validates after the access level changed; " +
+			"if tokens became independent of it, assert the new behaviour instead")
+	}
+	// The token for the new level works immediately, with no re-login.
+	if ok, _, access := ValidateUserToken(GenerateUserToken("alice", "admin")); !ok || access != "admin" {
+		t.Errorf("the promoted token was rejected (ok=%v access=%q)", ok, access)
+	}
+}
+
+// TestValidateUserTokenScansEveryUser records that validation is a linear scan:
+// for each request it loads every user and recomputes that user's token until
+// one matches. Cost grows with the size of the user table on every
+// authenticated call, and each call also opens its own SQLite connection while
+// the pool is limited to one.
+func TestValidateUserTokenScansEveryUser(t *testing.T) {
+	db := useTempDB(t)
+	for i := 0; i < 50; i++ {
+		insertUser(t, db, fmt.Sprintf("user%02d", i), "secret", "User", "guest")
+	}
+	insertUser(t, db, "last", "secret", "Last", "admin")
+
+	ok, username, _ := ValidateUserToken(GenerateUserToken("last", "admin"))
+	if !ok || username != "last" {
+		t.Errorf("the last user in the table was not matched (ok=%v username=%q)", ok, username)
+	}
+}

--- a/pkg/api/backup_handler_test.go
+++ b/pkg/api/backup_handler_test.go
@@ -1,0 +1,345 @@
+package api
+
+import (
+	"database/sql"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func insertBackupTask(t *testing.T, conn *sql.DB, enable int, cfg string) {
+	t.Helper()
+
+	if _, err := conn.Exec(
+		`INSERT INTO backup_tasks (enable, last_update_time, last_backup_time, next_backup_time, config_json)
+		 VALUES (?, '2026-08-20 00:00:00', '2026-08-20 18:00:00', '2026-08-21 18:00:00', ?)`,
+		enable, cfg); err != nil {
+		t.Fatalf("insert backup task: %v", err)
+	}
+}
+
+func backupConfig(t *testing.T, conn *sql.DB, id int) map[string]interface{} {
+	t.Helper()
+
+	var raw string
+	if err := conn.QueryRow("SELECT config_json FROM backup_tasks WHERE id=?", id).Scan(&raw); err != nil {
+		t.Fatalf("read config_json: %v", err)
+	}
+	var cfg map[string]interface{}
+	if err := json.Unmarshal([]byte(raw), &cfg); err != nil {
+		t.Fatalf("parse config_json %q: %v", raw, err)
+	}
+	return cfg
+}
+
+// ------------------------------------------------------------- BackupRun
+
+func TestBackupRunHandlerRejectsAnUnknownTask(t *testing.T) {
+	useTempTaskDB(t)
+
+	rec := httptest.NewRecorder()
+	serveWithURLParams(rec, httptest.NewRequest(http.MethodPost, "/backup/{id}/run", nil),
+		BackupRunHandler, map[string]string{"id": "999"})
+
+	resp := decodeEnvelope(t, rec)
+	if resp["success"] != false {
+		t.Errorf("success = %v, want false", resp["success"])
+	}
+	if resp["error"] != "backup task not found" {
+		t.Errorf("error = %v", resp["error"])
+	}
+}
+
+func TestBackupRunHandlerReportsAMissingTable(t *testing.T) {
+	emptyTaskDB(t)
+
+	rec := httptest.NewRecorder()
+	serveWithURLParams(rec, httptest.NewRequest(http.MethodPost, "/backup/{id}/run", nil),
+		BackupRunHandler, map[string]string{"id": "1"})
+
+	if resp := decodeEnvelope(t, rec); resp["success"] != false {
+		t.Errorf("success = %v, want false", resp["success"])
+	}
+}
+
+// "Manually triggered backup" runs no backup. The handler checks the task
+// exists, stamps last_backup_time with the current time, and answers "Backup
+// job started successfully" — no executor is constructed, no command is run,
+// nothing is written anywhere. The dashboard then shows a backup that happened
+// seconds ago and does not exist, which is worse than showing none: an operator
+// checking recoverability before a failover sees a fresh successful backup.
+func TestBackupRunHandlerRecordsASuccessWithoutRunningAnything(t *testing.T) {
+	conn := useTempTaskDB(t)
+	insertBackupTask(t, conn, 1, `{"name":"nightly","sourceType":"mongodb","schedule":"0 3 * * *"}`)
+
+	before := time.Now().UTC().Add(-time.Second)
+
+	rec := httptest.NewRecorder()
+	serveWithURLParams(rec, httptest.NewRequest(http.MethodPost, "/backup/{id}/run", nil),
+		BackupRunHandler, map[string]string{"id": "1"})
+
+	resp := decodeEnvelope(t, rec)
+	if resp["success"] != true {
+		t.Fatalf("success = %v (body: %s)", resp["success"], rec.Body.String())
+	}
+	if resp["message"] != "Backup job started successfully" {
+		t.Errorf("message = %v", resp["message"])
+	}
+
+	// The driver converts DATETIME columns to time.Time.
+	var lastBackup time.Time
+	if err := conn.QueryRow("SELECT last_backup_time FROM backup_tasks WHERE id=1").Scan(&lastBackup); err != nil {
+		t.Fatalf("read last_backup_time: %v", err)
+	}
+	if !lastBackup.After(before) {
+		t.Fatalf("last_backup_time = %v, expected it to be stamped with now — the handler appears to run a real backup now; assert the executed backup instead", lastBackup)
+	}
+
+	// Nothing else changed: no task status was registered, which is what a real
+	// asynchronous run does (see BackupExecuteHandler).
+	resetTaskStatus(t)
+	taskStatusMutex.RLock()
+	n := len(taskStatusMap)
+	taskStatusMutex.RUnlock()
+	if n != 0 {
+		t.Fatalf("%d background tasks were registered — the handler appears to execute now", n)
+	}
+}
+
+// ---------------------------------------------------------- BackupUpdate
+
+func TestBackupUpdateHandlerReplacesTheConfig(t *testing.T) {
+	conn := useTempTaskDB(t)
+	insertBackupTask(t, conn, 1, `{"name":"nightly","sourceType":"mongodb","schedule":"0 3 * * *","status":"enabled"}`)
+
+	body := `{"name":"renamed","sourceType":"mysql","schedule":"*/5 * * * *",
+	          "database":{"host":"h","port":"3306"},"destination":{"bucket":"b"},
+	          "format":"json","backupType":"full","compressionType":"gzip",
+	          "tableSelectionMode":"regex","regexPattern":"^orders_"}`
+
+	rec := httptest.NewRecorder()
+	serveWithURLParams(rec, httptest.NewRequest(http.MethodPut, "/backup/{id}", strings.NewReader(body)),
+		BackupUpdateHandler, map[string]string{"id": "1"})
+
+	resp := decodeEnvelope(t, rec)
+	if resp["success"] != true {
+		t.Fatalf("success = %v (body: %s)", resp["success"], rec.Body.String())
+	}
+
+	cfg := backupConfig(t, conn, 1)
+	for field, want := range map[string]interface{}{
+		"name": "renamed", "sourceType": "mysql", "schedule": "*/5 * * * *",
+		"format": "json", "backupType": "full", "compressionType": "gzip",
+		"tableSelectionMode": "regex", "regexPattern": "^orders_",
+	} {
+		if cfg[field] != want {
+			t.Errorf("%s = %v, want %v", field, cfg[field], want)
+		}
+	}
+	// status is carried over from the stored config, not the request.
+	if cfg["status"] != "enabled" {
+		t.Errorf("status = %v, want the preserved enabled", cfg["status"])
+	}
+}
+
+func TestBackupUpdateHandlerDerivesStatusFromEnable(t *testing.T) {
+	conn := useTempTaskDB(t)
+	// No "status" key in the stored config, enable = 1.
+	insertBackupTask(t, conn, 1, `{"name":"nightly"}`)
+
+	rec := httptest.NewRecorder()
+	serveWithURLParams(rec, httptest.NewRequest(http.MethodPut, "/backup/{id}", strings.NewReader(`{"name":"n"}`)),
+		BackupUpdateHandler, map[string]string{"id": "1"})
+	if resp := decodeEnvelope(t, rec); resp["success"] != true {
+		t.Fatalf("body: %s", rec.Body.String())
+	}
+
+	if got := backupConfig(t, conn, 1)["status"]; got != "enabled" {
+		t.Errorf("status = %v, want enabled (derived from enable=1)", got)
+	}
+}
+
+func TestBackupUpdateHandlerKeepsTheStoredNameWhenOmitted(t *testing.T) {
+	conn := useTempTaskDB(t)
+	insertBackupTask(t, conn, 1, `{"name":"keep me","status":"enabled"}`)
+
+	rec := httptest.NewRecorder()
+	serveWithURLParams(rec, httptest.NewRequest(http.MethodPut, "/backup/{id}", strings.NewReader(`{"sourceType":"mysql"}`)),
+		BackupUpdateHandler, map[string]string{"id": "1"})
+	if resp := decodeEnvelope(t, rec); resp["success"] != true {
+		t.Fatalf("body: %s", rec.Body.String())
+	}
+
+	if got := backupConfig(t, conn, 1)["name"]; got != "keep me" {
+		t.Errorf("name = %v, want the stored name", got)
+	}
+}
+
+func TestBackupUpdateHandlerGeneratesANameWhenThereIsNone(t *testing.T) {
+	conn := useTempTaskDB(t)
+	insertBackupTask(t, conn, 1, `{"status":"enabled"}`)
+
+	rec := httptest.NewRecorder()
+	serveWithURLParams(rec, httptest.NewRequest(http.MethodPut, "/backup/{id}", strings.NewReader(`{}`)),
+		BackupUpdateHandler, map[string]string{"id": "1"})
+	if resp := decodeEnvelope(t, rec); resp["success"] != true {
+		t.Fatalf("body: %s", rec.Body.String())
+	}
+
+	if got := backupConfig(t, conn, 1)["name"]; got != "Backup Task 1" {
+		t.Errorf("name = %v, want the generated default", got)
+	}
+}
+
+func TestBackupUpdateHandlerRejectsMalformedJSON(t *testing.T) {
+	conn := useTempTaskDB(t)
+	insertBackupTask(t, conn, 1, `{"name":"n"}`)
+
+	rec := httptest.NewRecorder()
+	serveWithURLParams(rec, httptest.NewRequest(http.MethodPut, "/backup/{id}", strings.NewReader(`{not json`)),
+		BackupUpdateHandler, map[string]string{"id": "1"})
+
+	if resp := decodeEnvelope(t, rec); resp["success"] != false {
+		t.Errorf("success = %v, want false", resp["success"])
+	}
+}
+
+func TestBackupUpdateHandlerRejectsAnUnknownTask(t *testing.T) {
+	useTempTaskDB(t)
+
+	rec := httptest.NewRecorder()
+	serveWithURLParams(rec, httptest.NewRequest(http.MethodPut, "/backup/{id}", strings.NewReader(`{"name":"n"}`)),
+		BackupUpdateHandler, map[string]string{"id": "999"})
+
+	resp := decodeEnvelope(t, rec)
+	if resp["success"] != false {
+		t.Errorf("success = %v, want false", resp["success"])
+	}
+	if resp["error"] != "fetch existing config fail" {
+		t.Errorf("error = %v", resp["error"])
+	}
+}
+
+func TestBackupUpdateHandlerToleratesACorruptStoredConfig(t *testing.T) {
+	conn := useTempTaskDB(t)
+	insertBackupTask(t, conn, 1, `{not json`)
+
+	rec := httptest.NewRecorder()
+	serveWithURLParams(rec, httptest.NewRequest(http.MethodPut, "/backup/{id}", strings.NewReader(`{"name":"n"}`)),
+		BackupUpdateHandler, map[string]string{"id": "1"})
+
+	if resp := decodeEnvelope(t, rec); resp["success"] != true {
+		t.Fatalf("a corrupt stored config was not recovered from: %s", rec.Body.String())
+	}
+	if got := backupConfig(t, conn, 1)["name"]; got != "n" {
+		t.Errorf("name = %v, want n", got)
+	}
+}
+
+// The update is a full replacement, not a merge: only name and status are read
+// back from the stored config. A client that PUTs a partial body — changing
+// just the schedule, say — silently blanks the database connection, the
+// destination, the format and everything else, and the backup stops working.
+func TestAPartialUpdateWipesTheRestOfTheConfig(t *testing.T) {
+	conn := useTempTaskDB(t)
+	insertBackupTask(t, conn, 1, `{
+		"name":"nightly","sourceType":"mongodb","status":"enabled",
+		"database":{"host":"tokyo","port":"27017","database":"app"},
+		"destination":{"bucket":"gs://backups"},
+		"format":"json","compressionType":"gzip","regexPattern":"^orders_"
+	}`)
+
+	// Change only the schedule.
+	rec := httptest.NewRecorder()
+	serveWithURLParams(rec, httptest.NewRequest(http.MethodPut, "/backup/{id}",
+		strings.NewReader(`{"schedule":"0 4 * * *"}`)),
+		BackupUpdateHandler, map[string]string{"id": "1"})
+	if resp := decodeEnvelope(t, rec); resp["success"] != true {
+		t.Fatalf("body: %s", rec.Body.String())
+	}
+
+	cfg := backupConfig(t, conn, 1)
+	if cfg["schedule"] != "0 4 * * *" {
+		t.Fatalf("schedule = %v, want the new value", cfg["schedule"])
+	}
+	if cfg["sourceType"] != "" || cfg["database"] != nil || cfg["destination"] != nil ||
+		cfg["format"] != "" || cfg["compressionType"] != "" || cfg["regexPattern"] != "" {
+		t.Fatalf("the untouched fields survived — the update appears to merge now; assert the merge instead: %#v", cfg)
+	}
+	// name and status are the only two that are carried over.
+	if cfg["name"] != "nightly" || cfg["status"] != "enabled" {
+		t.Errorf("name/status = %v/%v, want them preserved", cfg["name"], cfg["status"])
+	}
+}
+
+// The stored config's status and name are read with unchecked type assertions.
+// A value of any other JSON type panics, and with no Recoverer in the router
+// (T-072) that aborts the connection rather than returning a 500.
+func TestANonStringStatusPanics(t *testing.T) {
+	conn := useTempTaskDB(t)
+	insertBackupTask(t, conn, 1, `{"name":"n","status":123}`)
+
+	defer func() {
+		if recover() == nil {
+			t.Fatal("a numeric status no longer panics — the assertion appears to be checked now; assert the error response instead")
+		}
+	}()
+
+	rec := httptest.NewRecorder()
+	serveWithURLParams(rec, httptest.NewRequest(http.MethodPut, "/backup/{id}", strings.NewReader(`{"name":"x"}`)),
+		BackupUpdateHandler, map[string]string{"id": "1"})
+	_ = rec
+}
+
+func TestANonStringNamePanics(t *testing.T) {
+	conn := useTempTaskDB(t)
+	insertBackupTask(t, conn, 1, `{"name":42,"status":"enabled"}`)
+
+	defer func() {
+		if recover() == nil {
+			t.Fatal("a numeric name no longer panics — the assertion appears to be checked now; assert the error response instead")
+		}
+	}()
+
+	rec := httptest.NewRecorder()
+	// An empty name in the request makes the handler fall back to the stored one.
+	serveWithURLParams(rec, httptest.NewRequest(http.MethodPut, "/backup/{id}", strings.NewReader(`{}`)),
+		BackupUpdateHandler, map[string]string{"id": "1"})
+	_ = rec
+}
+
+// next_backup_time is written from calculateNextBackupTime, which ignores the
+// cron expression entirely (T-074), so every update stamps the same now+24h
+// regardless of the schedule the caller just set.
+func TestTheStoredNextBackupTimeIgnoresTheSchedule(t *testing.T) {
+	conn := useTempTaskDB(t)
+	insertBackupTask(t, conn, 1, `{"name":"n","status":"enabled"}`)
+
+	rec := httptest.NewRecorder()
+	serveWithURLParams(rec, httptest.NewRequest(http.MethodPut, "/backup/{id}",
+		strings.NewReader(`{"name":"n","schedule":"*/5 * * * *"}`)),
+		BackupUpdateHandler, map[string]string{"id": "1"})
+	if resp := decodeEnvelope(t, rec); resp["success"] != true {
+		t.Fatalf("body: %s", rec.Body.String())
+	}
+
+	var next time.Time
+	if err := conn.QueryRow("SELECT next_backup_time FROM backup_tasks WHERE id=1").Scan(&next); err != nil {
+		t.Fatalf("read next_backup_time: %v", err)
+	}
+	// A five-minute schedule should put the next run minutes away, not a day.
+	if d := time.Until(next); d < 23*time.Hour {
+		t.Fatalf("next_backup_time is %v away — the schedule appears to be parsed now; assert the real next run instead", d)
+	}
+}
+
+// emptyTaskDB points the package at a SQLite file with no tables.
+func emptyTaskDB(t *testing.T) {
+	t.Helper()
+	isolateCrontab(t)
+	t.Setenv("SYNC_DB_PATH", filepath.Join(t.TempDir(), "empty.db"))
+}

--- a/pkg/api/cronjob_handler_test.go
+++ b/pkg/api/cronjob_handler_test.go
@@ -1,0 +1,267 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+)
+
+// resetTaskStatus clears the package-global task registry so tests do not see
+// each other's entries.
+func resetTaskStatus(t *testing.T) {
+	t.Helper()
+
+	taskStatusMutex.Lock()
+	taskStatusMap = make(map[string]*BackupTaskStatus)
+	taskStatusMutex.Unlock()
+
+	t.Cleanup(func() {
+		taskStatusMutex.Lock()
+		taskStatusMap = make(map[string]*BackupTaskStatus)
+		taskStatusMutex.Unlock()
+	})
+}
+
+func TestTaskStatusRoundTrip(t *testing.T) {
+	resetTaskStatus(t)
+
+	want := &BackupTaskStatus{TaskID: "t1", BackupID: 7, Status: "pending", Message: "queued"}
+	setTaskStatus("t1", want)
+
+	got, ok := getTaskStatus("t1")
+	if !ok {
+		t.Fatal("getTaskStatus reported the task as missing")
+	}
+	if got != want {
+		t.Errorf("getTaskStatus returned %#v, want the stored pointer", got)
+	}
+}
+
+func TestGetTaskStatusMissing(t *testing.T) {
+	resetTaskStatus(t)
+
+	if _, ok := getTaskStatus("nope"); ok {
+		t.Error("getTaskStatus reported an unknown task as present")
+	}
+}
+
+func TestUpdateBackupTaskStatusRunning(t *testing.T) {
+	resetTaskStatus(t)
+	setTaskStatus("t1", &BackupTaskStatus{TaskID: "t1", Status: "pending"})
+
+	updateBackupTaskStatus("t1", "running", "started", nil)
+
+	got, _ := getTaskStatus("t1")
+	if got.Status != "running" || got.Message != "started" {
+		t.Errorf("status = %q, message = %q", got.Status, got.Message)
+	}
+	if got.Error != "" {
+		t.Errorf("Error = %q, want empty", got.Error)
+	}
+	if got.CompletedAt != nil {
+		t.Errorf("CompletedAt = %v, want nil while running", got.CompletedAt)
+	}
+}
+
+func TestUpdateBackupTaskStatusTerminalStatesStampCompletedAt(t *testing.T) {
+	for _, status := range []string{"completed", "failed"} {
+		t.Run(status, func(t *testing.T) {
+			resetTaskStatus(t)
+			setTaskStatus("t1", &BackupTaskStatus{TaskID: "t1", Status: "running"})
+
+			updateBackupTaskStatus("t1", status, "done", nil)
+
+			got, _ := getTaskStatus("t1")
+			if got.CompletedAt == nil {
+				t.Fatalf("CompletedAt is nil after reaching %q", status)
+			}
+			if d := time.Since(*got.CompletedAt); d < 0 || d > 2*time.Second {
+				t.Errorf("CompletedAt = %v, %v away from now", got.CompletedAt, d)
+			}
+		})
+	}
+}
+
+func TestUpdateBackupTaskStatusRecordsTheError(t *testing.T) {
+	resetTaskStatus(t)
+	setTaskStatus("t1", &BackupTaskStatus{TaskID: "t1", Status: "running"})
+
+	updateBackupTaskStatus("t1", "failed", "backup failed", errors.New("disk full"))
+
+	got, _ := getTaskStatus("t1")
+	if got.Error != "disk full" {
+		t.Errorf("Error = %q, want %q", got.Error, "disk full")
+	}
+}
+
+func TestUpdateBackupTaskStatusUnknownTaskIsSilent(t *testing.T) {
+	resetTaskStatus(t)
+
+	updateBackupTaskStatus("never-submitted", "failed", "boom", errors.New("x"))
+
+	if _, ok := getTaskStatus("never-submitted"); ok {
+		t.Error("updating an unknown task created an entry")
+	}
+}
+
+// A later update never clears an error a previous one recorded, so a task that
+// fails and is then retried into "completed" reports success while still
+// carrying the failure text.
+func TestARecoveredTaskKeepsItsStaleError(t *testing.T) {
+	resetTaskStatus(t)
+	setTaskStatus("t1", &BackupTaskStatus{TaskID: "t1", Status: "running"})
+
+	updateBackupTaskStatus("t1", "failed", "attempt 1 failed", errors.New("timeout"))
+	updateBackupTaskStatus("t1", "completed", "attempt 2 succeeded", nil)
+
+	got, _ := getTaskStatus("t1")
+	if got.Status != "completed" {
+		t.Fatalf("status = %q, want completed", got.Status)
+	}
+	if got.Error != "timeout" {
+		t.Fatalf("Error = %q, no longer stale — it appears to be cleared now; assert the empty error instead", got.Error)
+	}
+}
+
+// Nothing ever removes an entry from taskStatusMap: every backup run leaves a
+// BackupTaskStatus in memory for the lifetime of the process, and the only way
+// to reclaim it is a restart.
+func TestTaskStatusEntriesAreNeverEvicted(t *testing.T) {
+	resetTaskStatus(t)
+
+	for i := 0; i < 500; i++ {
+		id := fmt.Sprintf("task_%d", i)
+		setTaskStatus(id, &BackupTaskStatus{
+			TaskID:    id,
+			Status:    "completed",
+			CreatedAt: time.Now().Add(-30 * 24 * time.Hour),
+		})
+		updateBackupTaskStatus(id, "completed", "done", nil)
+	}
+
+	taskStatusMutex.RLock()
+	n := len(taskStatusMap)
+	taskStatusMutex.RUnlock()
+
+	if n != 500 {
+		t.Fatalf("taskStatusMap holds %d of 500 month-old completed tasks — eviction appears to have been added; assert the retention policy instead", n)
+	}
+}
+
+func TestBackupStatusHandlerReturnsTheStoredStatus(t *testing.T) {
+	resetTaskStatus(t)
+	setTaskStatus("backup_7_1", &BackupTaskStatus{
+		TaskID: "backup_7_1", BackupID: 7, Status: "running", Message: "in progress",
+	})
+
+	rec := httptest.NewRecorder()
+	serveWithURLParams(rec, httptest.NewRequest(http.MethodGet, "/backup/status/backup_7_1", nil),
+		BackupStatusHandler, map[string]string{"taskId": "backup_7_1"})
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	var got BackupTaskStatus
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("body is not a BackupTaskStatus: %v (%q)", err, rec.Body.String())
+	}
+	if got.TaskID != "backup_7_1" || got.BackupID != 7 || got.Status != "running" {
+		t.Errorf("got %#v", got)
+	}
+	if got.CompletedAt != nil {
+		t.Errorf("completedAt is present on a running task: %v", got.CompletedAt)
+	}
+}
+
+func TestBackupStatusHandlerUnknownTaskIs404(t *testing.T) {
+	resetTaskStatus(t)
+
+	rec := httptest.NewRecorder()
+	serveWithURLParams(rec, httptest.NewRequest(http.MethodGet, "/backup/status/nope", nil),
+		BackupStatusHandler, map[string]string{"taskId": "nope"})
+
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", rec.Code)
+	}
+}
+
+func TestBackupStatusHandlerEmptyTaskIDIs400(t *testing.T) {
+	resetTaskStatus(t)
+
+	rec := httptest.NewRecorder()
+	serveWithURLParams(rec, httptest.NewRequest(http.MethodGet, "/backup/status/", nil),
+		BackupStatusHandler, map[string]string{"taskId": ""})
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", rec.Code)
+	}
+}
+
+func TestBackupExecuteHandlerRejectsANonNumericID(t *testing.T) {
+	resetTaskStatus(t)
+
+	for _, id := range []string{"abc", "", "1.5", "7x"} {
+		rec := httptest.NewRecorder()
+		serveWithURLParams(rec, httptest.NewRequest(http.MethodPost, "/backup/execute/"+id, nil),
+			BackupExecuteHandler, map[string]string{"id": id})
+
+		if rec.Code != http.StatusBadRequest {
+			t.Errorf("id %q: status = %d, want 400", id, rec.Code)
+		}
+	}
+
+	taskStatusMutex.RLock()
+	n := len(taskStatusMap)
+	taskStatusMutex.RUnlock()
+	if n != 0 {
+		t.Errorf("a rejected request registered %d task(s)", n)
+	}
+}
+
+// The task ID is derived from the backup ID and a one-second timestamp, so two
+// runs of the same backup inside the same second produce the same ID and the
+// second silently replaces the first's status entry. The caller that submitted
+// the first run then polls a status that belongs to a different execution.
+func TestTaskIDsCollideWithinTheSameSecond(t *testing.T) {
+	resetTaskStatus(t)
+
+	now := time.Now().Unix()
+	first := fmt.Sprintf("backup_%d_%d", 7, now)
+	second := fmt.Sprintf("backup_%d_%d", 7, now)
+
+	if first != second {
+		t.Fatal("the ID format no longer collides within a second — it appears to include a unique component now")
+	}
+
+	setTaskStatus(first, &BackupTaskStatus{TaskID: first, BackupID: 7, Status: "running", Message: "run 1"})
+	setTaskStatus(second, &BackupTaskStatus{TaskID: second, BackupID: 7, Status: "pending", Message: "run 2"})
+
+	got, _ := getTaskStatus(first)
+	if got.Message != "run 2" {
+		t.Fatalf("message = %q — the collision no longer overwrites; assert the distinct entries instead", got.Message)
+	}
+
+	taskStatusMutex.RLock()
+	n := len(taskStatusMap)
+	taskStatusMutex.RUnlock()
+	if n != 1 {
+		t.Fatalf("taskStatusMap holds %d entries for two runs — the IDs appear to be unique now", n)
+	}
+}
+
+// serveWithURLParams runs a handler with chi route parameters populated, which
+// is how the handlers read {id} and {taskId}.
+func serveWithURLParams(rec *httptest.ResponseRecorder, req *http.Request, h http.HandlerFunc, params map[string]string) {
+	rctx := chi.NewRouteContext()
+	for k, v := range params {
+		rctx.URLParams.Add(k, v)
+	}
+	h(rec, req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx)))
+}

--- a/pkg/api/db_utils_test.go
+++ b/pkg/api/db_utils_test.go
@@ -1,0 +1,396 @@
+package api
+
+import (
+	"database/sql"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+// useTempDB points the package at a throwaway SQLite file carrying the same
+// schema as sync.db, so the user and auth-config helpers can be exercised
+// without touching the database tracked in this repository.
+func useTempDB(t *testing.T) *sql.DB {
+	t.Helper()
+
+	isolateCrontab(t)
+
+	path := filepath.Join(t.TempDir(), "sync.db")
+	t.Setenv("SYNC_DB_PATH", path)
+
+	db, err := sql.Open("sqlite3", path)
+	if err != nil {
+		t.Fatalf("open temp sqlite: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	const schema = `
+CREATE TABLE users (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    username   TEXT NOT NULL UNIQUE,
+    password   TEXT NOT NULL,
+    name       TEXT NOT NULL,
+    avatar     TEXT,
+    userId     TEXT,
+    email      TEXT,
+    access     TEXT NOT NULL,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    status     TEXT DEFAULT 'active'
+);
+CREATE TABLE auth_configs (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    provider    TEXT NOT NULL UNIQUE,
+    config_json TEXT NOT NULL,
+    created_at  DATETIME DEFAULT CURRENT_TIMESTAMP,
+    updated_at  DATETIME DEFAULT CURRENT_TIMESTAMP,
+    enabled     BOOLEAN DEFAULT false
+);`
+	if _, err := db.Exec(schema); err != nil {
+		t.Fatalf("create schema: %v", err)
+	}
+	return db
+}
+
+func insertUser(t *testing.T, db *sql.DB, username, password, name, access string) {
+	t.Helper()
+
+	if _, err := db.Exec(
+		`INSERT INTO users (username, password, name, access) VALUES (?, ?, ?, ?)`,
+		username, password, name, access); err != nil {
+		t.Fatalf("insert user %q: %v", username, err)
+	}
+}
+
+func TestGetUserByUsername(t *testing.T) {
+	db := useTempDB(t)
+	insertUser(t, db, "alice", "secret", "Alice", "admin")
+
+	user, err := GetUserByUsername("alice")
+	if err != nil {
+		t.Fatalf("GetUserByUsername: %v", err)
+	}
+
+	if user["username"] != "alice" || user["name"] != "Alice" || user["access"] != "admin" {
+		t.Errorf("user = %+v", user)
+	}
+	// NULL columns are normalised to empty strings rather than nil, so callers
+	// can type-assert without checking.
+	for _, key := range []string{"avatar", "userId", "email"} {
+		if user[key] != "" {
+			t.Errorf("%s = %#v, want an empty string", key, user[key])
+		}
+	}
+	// A NULL status defaults to active.
+	if user["status"] != "active" {
+		t.Errorf("status = %#v, want active", user["status"])
+	}
+}
+
+func TestGetUserByUsernameMissing(t *testing.T) {
+	useTempDB(t)
+
+	_, err := GetUserByUsername("nobody")
+	if err != sql.ErrNoRows {
+		t.Errorf("GetUserByUsername for a missing user returned %v, want sql.ErrNoRows", err)
+	}
+}
+
+func TestValidateUser(t *testing.T) {
+	db := useTempDB(t)
+	insertUser(t, db, "alice", "secret", "Alice", "admin")
+
+	t.Run("correct password", func(t *testing.T) {
+		ok, access, err := ValidateUser("alice", "secret")
+		if err != nil {
+			t.Fatalf("ValidateUser: %v", err)
+		}
+		if !ok || access != "admin" {
+			t.Errorf("ValidateUser = %v/%q, want true/admin", ok, access)
+		}
+	})
+
+	t.Run("wrong password", func(t *testing.T) {
+		ok, access, err := ValidateUser("alice", "wrong")
+		if err != nil {
+			t.Fatalf("ValidateUser: %v", err)
+		}
+		if ok || access != "" {
+			t.Errorf("ValidateUser = %v/%q, want false/empty", ok, access)
+		}
+	})
+
+	t.Run("unknown user is not an error", func(t *testing.T) {
+		// sql.ErrNoRows is swallowed so a missing user is indistinguishable
+		// from a wrong password, which is the right choice for a login form.
+		ok, _, err := ValidateUser("nobody", "secret")
+		if err != nil {
+			t.Errorf("ValidateUser returned %v, want nil", err)
+		}
+		if ok {
+			t.Error("ValidateUser accepted an unknown user")
+		}
+	})
+}
+
+// TestPasswordsAreStoredInCleartext records that no hashing takes place
+// anywhere in the credential path: UpdateUserPassword writes the value it is
+// given, and ValidateUser compares it to the submitted password with ==. The
+// production database copy in docs/ shows the same, an admin password of
+// sixteen printable characters rather than a hash.
+//
+// The comparison is also not constant time, so it leaks timing information,
+// but that is secondary to the passwords being readable by anyone who can open
+// the file.
+func TestPasswordsAreStoredInCleartext(t *testing.T) {
+	db := useTempDB(t)
+	insertUser(t, db, "alice", "initial", "Alice", "admin")
+
+	if err := UpdateUserPassword("alice", "a-brand-new-password"); err != nil {
+		t.Fatalf("UpdateUserPassword: %v", err)
+	}
+
+	var stored string
+	if err := db.QueryRow("SELECT password FROM users WHERE username = 'alice'").Scan(&stored); err != nil {
+		t.Fatalf("read password: %v", err)
+	}
+
+	if stored != "a-brand-new-password" {
+		t.Fatalf("the stored value is %q; hashing may have been introduced, "+
+			"which would be an improvement", stored)
+	}
+}
+
+func TestUpdateUserPasswordUnknownUserIsSilent(t *testing.T) {
+	useTempDB(t)
+
+	// UPDATE affects no rows and reports no error, so a caller that mistypes a
+	// username believes the password was changed.
+	if err := UpdateUserPassword("nobody", "x"); err != nil {
+		t.Errorf("UpdateUserPassword for a missing user returned %v; if it now "+
+			"reports the miss, assert that instead", err)
+	}
+}
+
+func TestGetUserDataStripsPassword(t *testing.T) {
+	db := useTempDB(t)
+	insertUser(t, db, "alice", "secret", "Alice", "admin")
+
+	data, err := GetUserData("alice")
+	if err != nil {
+		t.Fatalf("GetUserData: %v", err)
+	}
+
+	if _, present := data["password"]; present {
+		t.Error("GetUserData returned the password field")
+	}
+	if data["username"] != "alice" {
+		t.Errorf("username = %#v", data["username"])
+	}
+}
+
+func TestGetAllUsers(t *testing.T) {
+	db := useTempDB(t)
+	insertUser(t, db, "alice", "s1", "Alice", "admin")
+	insertUser(t, db, "bob", "s2", "Bob", "guest")
+
+	users, err := GetAllUsers()
+	if err != nil {
+		t.Fatalf("GetAllUsers: %v", err)
+	}
+	if len(users) != 2 {
+		t.Fatalf("GetAllUsers returned %d users, want 2", len(users))
+	}
+
+	// Unlike GetUserData, this one keeps the password in the map. Callers are
+	// responsible for stripping it; GetUsersHandler builds a whitelist response
+	// and ValidateUserToken only reads username and access.
+	if _, present := users[0]["password"]; !present {
+		t.Error("GetAllUsers no longer returns the password; callers that relied " +
+			"on stripping it can be simplified")
+	}
+}
+
+func TestGetAllUsersEmpty(t *testing.T) {
+	useTempDB(t)
+
+	users, err := GetAllUsers()
+	if err != nil {
+		t.Fatalf("GetAllUsers: %v", err)
+	}
+	if len(users) != 0 {
+		t.Errorf("GetAllUsers returned %d users, want none", len(users))
+	}
+}
+
+func TestSaveGoogleUserCreatesAndUpdates(t *testing.T) {
+	db := useTempDB(t)
+
+	t.Run("creates a guest account", func(t *testing.T) {
+		username, access, err := SaveGoogleUser("jack@example.com", "Jack")
+		if err != nil {
+			t.Fatalf("SaveGoogleUser: %v", err)
+		}
+		if username != "jack@example.com" {
+			t.Errorf("username = %q, want the email address", username)
+		}
+		if access != "guest" {
+			t.Errorf("access = %q, want guest", access)
+		}
+
+		var name, userID string
+		if err := db.QueryRow(
+			`SELECT name, userId FROM users WHERE email = 'jack@example.com'`).Scan(&name, &userID); err != nil {
+			t.Fatalf("read user: %v", err)
+		}
+		if name != "Jack" {
+			t.Errorf("name = %q", name)
+		}
+		if !strings.HasPrefix(userID, "g_") {
+			t.Errorf("userId = %q, want a g_ prefix", userID)
+		}
+	})
+
+	t.Run("second login updates rather than duplicates", func(t *testing.T) {
+		if _, _, err := SaveGoogleUser("jack@example.com", "Jack Renamed"); err != nil {
+			t.Fatalf("SaveGoogleUser: %v", err)
+		}
+
+		var count int
+		if err := db.QueryRow(
+			`SELECT COUNT(*) FROM users WHERE email = 'jack@example.com'`).Scan(&count); err != nil {
+			t.Fatalf("count users: %v", err)
+		}
+		if count != 1 {
+			t.Errorf("the account was duplicated: %d rows", count)
+		}
+
+		var name string
+		if err := db.QueryRow(
+			`SELECT name FROM users WHERE email = 'jack@example.com'`).Scan(&name); err != nil {
+			t.Fatalf("read name: %v", err)
+		}
+		if name != "Jack Renamed" {
+			t.Errorf("name = %q, want the updated value", name)
+		}
+	})
+
+	t.Run("an existing access level is preserved", func(t *testing.T) {
+		if _, err := db.Exec(
+			`UPDATE users SET access = 'admin' WHERE email = 'jack@example.com'`); err != nil {
+			t.Fatalf("promote user: %v", err)
+		}
+
+		_, access, err := SaveGoogleUser("jack@example.com", "Jack")
+		if err != nil {
+			t.Fatalf("SaveGoogleUser: %v", err)
+		}
+		// A returning user keeps whatever level an administrator granted; the
+		// guest default only applies on creation.
+		if access != "admin" {
+			t.Errorf("access = %q, want admin", access)
+		}
+	})
+}
+
+// TestGeneratedGooglePasswordIsPredictable records that generateRandomPassword
+// is not random. It returns "google_" followed by the current time formatted to
+// the second, so the credential for an account created by Google sign-in can be
+// reconstructed by anyone who knows roughly when it was created — a few hundred
+// guesses covers a wide window.
+//
+// This matters because ValidateUser accepts password logins for every account,
+// including ones created through Google, so a predictable password is a way
+// into the account without going through Google at all.
+func TestGeneratedGooglePasswordIsPredictable(t *testing.T) {
+	got := generateRandomPassword()
+
+	if !regexp.MustCompile(`^google_\d{14}$`).MatchString(got) {
+		t.Fatalf("generateRandomPassword produced %q; the scheme may have changed, "+
+			"so assert the new one instead", got)
+	}
+	// Reconstructing it needs nothing but a clock.
+	if want := "google_" + time.Now().Format("20060102150405"); got != want {
+		t.Errorf("generateRandomPassword = %q, and the current second gives %q; "+
+			"they normally match", got, want)
+	}
+	// Two calls inside one second are identical, which is the whole problem.
+	if second := generateRandomPassword(); second != got {
+		t.Logf("the two calls straddled a second boundary (%q vs %q)", got, second)
+	}
+}
+
+func TestAuthConfigRoundTrip(t *testing.T) {
+	useTempDB(t)
+
+	err := UpdateAuthConfig("google", map[string]interface{}{
+		"client_id":     "id-123",
+		"client_secret": "secret-456",
+		"enabled":       true,
+	})
+	if err != nil {
+		t.Fatalf("UpdateAuthConfig: %v", err)
+	}
+
+	got, err := GetAuthConfig("google")
+	if err != nil {
+		t.Fatalf("GetAuthConfig: %v", err)
+	}
+	if got["client_id"] != "id-123" || got["client_secret"] != "secret-456" {
+		t.Errorf("config = %+v", got)
+	}
+	// enabled is stored in its own column and merged back in on read.
+	if got["enabled"] != true {
+		t.Errorf("enabled = %#v, want true", got["enabled"])
+	}
+}
+
+func TestUpdateAuthConfigOverwrites(t *testing.T) {
+	useTempDB(t)
+
+	if err := UpdateAuthConfig("google", map[string]interface{}{"client_id": "first", "enabled": true}); err != nil {
+		t.Fatalf("first UpdateAuthConfig: %v", err)
+	}
+	if err := UpdateAuthConfig("google", map[string]interface{}{"client_id": "second", "enabled": false}); err != nil {
+		t.Fatalf("second UpdateAuthConfig: %v", err)
+	}
+
+	got, err := GetAuthConfig("google")
+	if err != nil {
+		t.Fatalf("GetAuthConfig: %v", err)
+	}
+	if got["client_id"] != "second" {
+		t.Errorf("client_id = %#v, want the updated value", got["client_id"])
+	}
+	if got["enabled"] != false {
+		t.Errorf("enabled = %#v, want false", got["enabled"])
+	}
+}
+
+func TestGetAuthConfigMissingProvider(t *testing.T) {
+	useTempDB(t)
+
+	if _, err := GetAuthConfig("github"); err != sql.ErrNoRows {
+		t.Errorf("GetAuthConfig for an unknown provider returned %v, want sql.ErrNoRows", err)
+	}
+}
+
+// TestUpdateAuthConfigMutatesTheCallersMap records a side effect: the function
+// deletes "enabled" from the map it was handed, because that value goes to its
+// own column. A caller that reuses the map afterwards silently loses the field.
+func TestUpdateAuthConfigMutatesTheCallersMap(t *testing.T) {
+	useTempDB(t)
+
+	cfg := map[string]interface{}{"client_id": "id", "enabled": true}
+	if err := UpdateAuthConfig("google", cfg); err != nil {
+		t.Fatalf("UpdateAuthConfig: %v", err)
+	}
+
+	if _, present := cfg["enabled"]; present {
+		t.Error("the caller's map kept its enabled key; the function may now copy " +
+			"before deleting, which would be an improvement")
+	}
+}

--- a/pkg/api/handler_input_test.go
+++ b/pkg/api/handler_input_test.go
@@ -1,0 +1,303 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// postJSON runs a handler over a request body and returns the recorder.
+func postJSON(h http.HandlerFunc, method, path, body string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(method, path, strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	h(rec, req)
+	return rec
+}
+
+// resetSessionGlobals restores the package-level session variables, which
+// several handlers both read and write.
+func resetSessionGlobals(t *testing.T) {
+	t.Helper()
+
+	prevAccess, prevUser := access, currentUsername
+	t.Cleanup(func() {
+		access, currentUsername = prevAccess, prevUser
+	})
+	access, currentUsername = "", ""
+}
+
+func TestHandlersRejectMalformedJSON(t *testing.T) {
+	cases := []struct {
+		name    string
+		handler http.HandlerFunc
+		method  string
+		path    string
+	}{
+		{"login", AuthLoginHandler, http.MethodPost, "/login"},
+		{"google callback", AuthGoogleCallbackHandler, http.MethodPost, "/login/google/callback"},
+		{"test connection", TestConnectionHandler, http.MethodPost, "/test-connection"},
+		{"user access", UpdateUserAccessHandler, http.MethodPut, "/users/access"},
+		{"delete user", DeleteUserHandler, http.MethodDelete, "/users"},
+		{"execute sql", ExecuteSQLHandler, http.MethodPost, "/sql/execute"},
+		{"table schema", GetTableSchemaHandler, http.MethodPost, "/tables/schema"},
+	}
+
+	for _, tc := range cases {
+		for _, body := range []string{"", "{", "not json", `{"a":}`, `[1,2,3`} {
+			t.Run(fmt.Sprintf("%s/%q", tc.name, body), func(t *testing.T) {
+				resetSessionGlobals(t)
+
+				rec := postJSON(tc.handler, tc.method, tc.path, body)
+				if rec.Code != http.StatusBadRequest {
+					t.Errorf("status = %d, want 400 (body: %q)", rec.Code, rec.Body.String())
+				}
+			})
+		}
+	}
+}
+
+func TestUpdateUserAccessRejectsAnEmptyUserID(t *testing.T) {
+	resetSessionGlobals(t)
+
+	rec := postJSON(UpdateUserAccessHandler, http.MethodPut, "/users/access", `{"access":"admin"}`)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", rec.Code)
+	}
+}
+
+func TestUpdateUserAccessRejectsAnUnknownAccessLevel(t *testing.T) {
+	resetSessionGlobals(t)
+
+	for _, level := range []string{"root", "superuser", "Admin", "GUEST", "owner"} {
+		body := fmt.Sprintf(`{"userId":"u1","access":%q}`, level)
+		rec := postJSON(UpdateUserAccessHandler, http.MethodPut, "/users/access", body)
+
+		var resp map[string]interface{}
+		if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("access %q: body is not JSON: %v (%q)", level, err, rec.Body.String())
+		}
+		if resp["success"] != false {
+			t.Errorf("access %q: success = %v, want false", level, resp["success"])
+		}
+	}
+}
+
+// An invalid access level is reported in the body but served as 200 OK, so a
+// client that branches on the status code treats a rejected privilege change
+// as applied.
+func TestARejectedAccessLevelStillReturnsHTTP200(t *testing.T) {
+	resetSessionGlobals(t)
+
+	rec := postJSON(UpdateUserAccessHandler, http.MethodPut, "/users/access", `{"userId":"u1","access":"root"}`)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d — the handler appears to return a real status now; assert it instead", rec.Code)
+	}
+}
+
+func TestDeleteUserRejectsAnEmptyUserID(t *testing.T) {
+	resetSessionGlobals(t)
+
+	rec := postJSON(DeleteUserHandler, http.MethodDelete, "/users", `{"userId":""}`)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", rec.Code)
+	}
+}
+
+func TestAuthCurrentUserRequiresAToken(t *testing.T) {
+	resetSessionGlobals(t)
+
+	for _, header := range []string{"", "Bearer", "Bearer nonsense", "nonsense", "Basic dXNlcjpwYXNz"} {
+		req := httptest.NewRequest(http.MethodGet, "/currentUser", nil)
+		if header != "" {
+			req.Header.Set("Authorization", header)
+		}
+		rec := httptest.NewRecorder()
+
+		AuthCurrentUserHandler(rec, req)
+
+		if rec.Code != http.StatusUnauthorized {
+			t.Errorf("Authorization %q: status = %d, want 401", header, rec.Code)
+		}
+	}
+}
+
+// The 401 body carries "success": true alongside errorCode 401, so a client
+// keying off that field reads an authentication failure as a success.
+func TestTheUnauthorizedBodyClaimsSuccess(t *testing.T) {
+	resetSessionGlobals(t)
+
+	rec := httptest.NewRecorder()
+	AuthCurrentUserHandler(rec, httptest.NewRequest(http.MethodGet, "/currentUser", nil))
+
+	var resp map[string]interface{}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("body is not JSON: %v (%q)", err, rec.Body.String())
+	}
+	if resp["success"] != true {
+		t.Fatalf("success = %v — the 401 body appears to be fixed; assert false instead", resp["success"])
+	}
+	if resp["errorCode"] != "401" {
+		t.Errorf("errorCode = %v, want \"401\"", resp["errorCode"])
+	}
+}
+
+func TestUpdateAdminPasswordRequiresAnAuthorizationHeader(t *testing.T) {
+	resetSessionGlobals(t)
+
+	rec := postJSON(UpdateAdminPasswordHandler, http.MethodPut, "/updateAdminPassword", `{"newPassword":"x"}`)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401", rec.Code)
+	}
+}
+
+func TestUpdateAdminPasswordRejectsANonAdminToken(t *testing.T) {
+	resetSessionGlobals(t)
+
+	req := httptest.NewRequest(http.MethodPut, "/updateAdminPassword", strings.NewReader(`{"newPassword":"x"}`))
+	req.Header.Set("Authorization", "Bearer "+GenerateUserToken("bob", "guest"))
+	rec := httptest.NewRecorder()
+
+	UpdateAdminPasswordHandler(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401", rec.Code)
+	}
+}
+
+func TestUpdatePasswordRequiresAnIdentity(t *testing.T) {
+	resetSessionGlobals(t)
+
+	rec := postJSON(UpdatePasswordHandler, http.MethodPut, "/updatePassword", `{"newPassword":"x"}`)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401", rec.Code)
+	}
+}
+
+func TestGetOAuthConfigRequiresAProvider(t *testing.T) {
+	resetSessionGlobals(t)
+
+	rec := httptest.NewRecorder()
+	GetOAuthConfigHandler(rec, httptest.NewRequest(http.MethodGet, "/oauth//config", nil))
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", rec.Code)
+	}
+}
+
+func TestUpdateOAuthConfigRequiresAnAdminToken(t *testing.T) {
+	resetSessionGlobals(t)
+
+	t.Run("no header", func(t *testing.T) {
+		rec := postJSON(UpdateOAuthConfigHandler, http.MethodPut, "/oauth/google/config", `{}`)
+		if rec.Code != http.StatusUnauthorized {
+			t.Errorf("status = %d, want 401", rec.Code)
+		}
+	})
+
+	t.Run("guest token", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPut, "/oauth/google/config", strings.NewReader(`{}`))
+		req.Header.Set("Authorization", "Bearer "+GenerateUserToken("bob", "guest"))
+		rec := httptest.NewRecorder()
+
+		UpdateOAuthConfigHandler(rec, req)
+
+		if rec.Code != http.StatusForbidden {
+			t.Errorf("status = %d, want 403", rec.Code)
+		}
+	})
+}
+
+// The session is a pair of package-level variables rather than per-request
+// state, so there is exactly one "current user" for the whole process. A
+// second client logging in silently reassigns who every session-reading
+// handler thinks it is talking to.
+func TestTheSessionIsProcessGlobal(t *testing.T) {
+	resetSessionGlobals(t)
+
+	access, currentUsername = "admin", "admin"
+
+	// Nobody presents a credential, yet the admin-only handler answers.
+	rec := httptest.NewRecorder()
+	GetAdminTokenHandler(rec, httptest.NewRequest(http.MethodGet, "/getAdminToken", nil))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d — the handler appears to read per-request state now; assert that instead", rec.Code)
+	}
+
+	var resp map[string]interface{}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("body is not JSON: %v (%q)", err, rec.Body.String())
+	}
+	data, _ := resp["data"].(map[string]interface{})
+	token, _ := data["accessToken"].(string)
+	if !ValidateAdminToken(token) {
+		t.Fatalf("no admin token was issued to an unauthenticated caller (body: %s)", rec.Body.String())
+	}
+}
+
+// Logging out is a global operation: it clears the one session pair, so one
+// client's logout revokes the session every other client is riding on.
+func TestLogoutClearsTheSessionForEveryone(t *testing.T) {
+	resetSessionGlobals(t)
+
+	access, currentUsername = "admin", "admin"
+
+	rec := httptest.NewRecorder()
+	AuthLogoutHandler(rec, httptest.NewRequest(http.MethodPost, "/logout", nil))
+
+	if access != "" || currentUsername != "" {
+		t.Fatalf("access = %q, currentUsername = %q — logout appears to be per-session now", access, currentUsername)
+	}
+
+	rec = httptest.NewRecorder()
+	GetAdminTokenHandler(rec, httptest.NewRequest(http.MethodGet, "/getAdminToken", nil))
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("after logout the admin handler returned %d, want 401", rec.Code)
+	}
+}
+
+// The session variables are written from handler goroutines with no
+// synchronisation, so concurrent requests race on them. Demonstrating that
+// costs the whole package: the race detector aborts it, and CI runs
+// `go test -race ./...`. The test is therefore skipped unless asked for.
+//
+//	SYNC_RACE_PROOF=1 go test -race -run TestConcurrentLoginsRace ./pkg/api/
+//
+// See T-070 in docs/TEST_FINDINGS.md.
+func TestConcurrentLoginsRaceOnTheSessionGlobals(t *testing.T) {
+	if os.Getenv("SYNC_RACE_PROOF") == "" {
+		t.Skip("set SYNC_RACE_PROOF=1 together with -race to demonstrate T-070")
+	}
+
+	resetSessionGlobals(t)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			rec := httptest.NewRecorder()
+			GetAdminTokenHandler(rec, httptest.NewRequest(http.MethodGet, "/getAdminToken", nil))
+		}()
+	}
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			rec := httptest.NewRecorder()
+			AuthLogoutHandler(rec, httptest.NewRequest(http.MethodPost, "/logout", nil))
+		}()
+	}
+	wg.Wait()
+}

--- a/pkg/api/integration_test.go
+++ b/pkg/api/integration_test.go
@@ -1,0 +1,627 @@
+//go:build integration
+
+package api
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	_ "github.com/go-sql-driver/mysql"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+
+	"github.com/retail-ai-inc/sync/pkg/config"
+	"github.com/retail-ai-inc/sync/test/harness"
+)
+
+const (
+	schemaSourceDB = "source_db"
+	schemaTargetDB = "target_db"
+)
+
+func openSchemaMySQL(t *testing.T, endpoint, database string) *sql.DB {
+	t.Helper()
+
+	host, port := harness.SplitHostPort(t, endpoint)
+	dsn := config.BuildDSNByType("mysql", map[string]string{
+		"user": "root", "password": "root", "host": host, "port": port, "database": database,
+	})
+	db, err := sql.Open("mysql", dsn)
+	if err != nil {
+		t.Fatalf("open %s: %v", endpoint, err)
+	}
+	if err := db.Ping(); err != nil {
+		t.Fatalf("ping %s: %v", endpoint, err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	return db
+}
+
+// schemaRequestBody builds a POST /api/tables/schema body for the MySQL source.
+func schemaRequestBody(t *testing.T, table string) []byte {
+	t.Helper()
+
+	host, port := harness.SplitHostPort(t, harness.MySQLSource)
+	body, err := json.Marshal(map[string]interface{}{
+		"sourceType": "mysql",
+		"connection": map[string]string{
+			"host": host, "port": port, "user": "root", "password": "root",
+			"database": schemaSourceDB,
+		},
+		"tableName": table,
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return body
+}
+
+func postSchema(t *testing.T, body []byte) (*httptest.ResponseRecorder, map[string]interface{}) {
+	t.Helper()
+
+	req := httptest.NewRequest(http.MethodPost, "/tables/schema", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	GetTableSchemaHandler(rec, req)
+
+	var resp map[string]interface{}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("body is not JSON: %v (%q)", err, rec.Body.String())
+	}
+	return rec, resp
+}
+
+func fieldsFrom(t *testing.T, resp map[string]interface{}) []map[string]interface{} {
+	t.Helper()
+
+	data, ok := resp["data"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("data is missing: %#v", resp)
+	}
+	raw, ok := data["fields"].([]interface{})
+	if !ok {
+		t.Fatalf("fields is missing: %#v", data)
+	}
+	out := make([]map[string]interface{}, 0, len(raw))
+	for _, f := range raw {
+		out = append(out, f.(map[string]interface{}))
+	}
+	return out
+}
+
+func TestGetMySQLSchemaReturnsColumnsAndTypes(t *testing.T) {
+	table := harness.UniqueName("schema")
+	src := openSchemaMySQL(t, harness.MySQLSource, schemaSourceDB)
+
+	if _, err := src.Exec(fmt.Sprintf(`
+		CREATE TABLE %s (
+			id     INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+			email  VARCHAR(100) NOT NULL,
+			amount DECIMAL(10,2),
+			note   TEXT,
+			active TINYINT(1) DEFAULT 1
+		)`, table)); err != nil {
+		t.Fatalf("create table: %v", err)
+	}
+	t.Cleanup(func() { _, _ = src.Exec("DROP TABLE " + table) })
+
+	rec, resp := postSchema(t, schemaRequestBody(t, table))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d (body: %s)", rec.Code, rec.Body.String())
+	}
+	if resp["success"] != true {
+		t.Fatalf("success = %v", resp["success"])
+	}
+
+	byName := map[string]map[string]interface{}{}
+	for _, f := range fieldsFrom(t, resp) {
+		byName[f["name"].(string)] = f
+	}
+	if len(byName) != 5 {
+		t.Fatalf("got %d fields, want 5: %v", len(byName), byName)
+	}
+
+	// COLUMN_TYPE is reported verbatim, including the width and precision.
+	for name, wantType := range map[string]string{
+		"id":     "int",
+		"email":  "varchar(100)",
+		"amount": "decimal(10,2)",
+		"note":   "text",
+		"active": "tinyint(1)",
+	} {
+		f, ok := byName[name]
+		if !ok {
+			t.Errorf("field %q is missing", name)
+			continue
+		}
+		if f["type"] != wantType {
+			t.Errorf("%s type = %v, want %v", name, f["type"], wantType)
+		}
+	}
+
+	if byName["id"]["isPrimary"] != true {
+		t.Errorf("id isPrimary = %v, want true", byName["id"]["isPrimary"])
+	}
+	for _, name := range []string{"email", "amount", "note", "active"} {
+		if byName[name]["isPrimary"] != false {
+			t.Errorf("%s isPrimary = %v, want false", name, byName[name]["isPrimary"])
+		}
+	}
+}
+
+func TestGetMySQLSchemaPutsThePrimaryKeyFirst(t *testing.T) {
+	table := harness.UniqueName("schemaorder")
+	src := openSchemaMySQL(t, harness.MySQLSource, schemaSourceDB)
+
+	// Declare the primary key last so ordinal position and sorted order differ.
+	if _, err := src.Exec(fmt.Sprintf(
+		"CREATE TABLE %s (zeta INT, alpha INT, mid INT, pk INT NOT NULL PRIMARY KEY)", table)); err != nil {
+		t.Fatalf("create table: %v", err)
+	}
+	t.Cleanup(func() { _, _ = src.Exec("DROP TABLE " + table) })
+
+	_, resp := postSchema(t, schemaRequestBody(t, table))
+
+	var order []string
+	for _, f := range fieldsFrom(t, resp) {
+		order = append(order, f["name"].(string))
+	}
+	want := []string{"pk", "alpha", "mid", "zeta"}
+	for i := range want {
+		if i >= len(order) || order[i] != want[i] {
+			t.Fatalf("order = %v, want %v", order, want)
+		}
+	}
+}
+
+// A composite primary key has no defined order (T-076): sortFieldsByName's
+// comparator reports less(i,j) and less(j,i) both true for two primary fields,
+// so sort.Slice is outside its contract and the primary columns come out
+// neither in declaration order nor sorted by name.
+func TestACompositePrimaryKeyHasNoDefinedOrder(t *testing.T) {
+	table := harness.UniqueName("schemacomposite")
+	src := openSchemaMySQL(t, harness.MySQLSource, schemaSourceDB)
+
+	if _, err := src.Exec(fmt.Sprintf(
+		"CREATE TABLE %s (zz_pk INT NOT NULL, aa_pk INT NOT NULL, mm_pk INT NOT NULL, payload INT, PRIMARY KEY (zz_pk, aa_pk, mm_pk))",
+		table)); err != nil {
+		t.Fatalf("create table: %v", err)
+	}
+	t.Cleanup(func() { _, _ = src.Exec("DROP TABLE " + table) })
+
+	_, resp := postSchema(t, schemaRequestBody(t, table))
+
+	fields := fieldsFrom(t, resp)
+	var primaries []string
+	for _, f := range fields {
+		if f["isPrimary"] == true {
+			primaries = append(primaries, f["name"].(string))
+		}
+	}
+	if len(primaries) != 3 {
+		t.Fatalf("got %d primary fields, want 3: %v", len(primaries), primaries)
+	}
+
+	sorted := true
+	for i := 1; i < len(primaries); i++ {
+		if primaries[i-1] > primaries[i] {
+			sorted = false
+		}
+	}
+	if sorted {
+		t.Fatalf("the primary columns came out sorted (%v) — sortFieldsByName appears to be fixed; assert the sorted order instead", primaries)
+	}
+}
+
+// A table that does not exist is not an error: INFORMATION_SCHEMA simply
+// returns no rows, and the handler answers 200 with an empty field list. The
+// only trace is a warn-level log line, so a client cannot distinguish "this
+// table has no columns" from "this table does not exist".
+func TestAMissingTableLooksLikeAnEmptySchema(t *testing.T) {
+	_, resp := postSchema(t, schemaRequestBody(t, "table_that_does_not_exist"))
+
+	if resp["success"] != true {
+		t.Fatalf("success = %v — a missing table appears to be reported now; assert the error instead", resp["success"])
+	}
+	data := resp["data"].(map[string]interface{})
+	if data["fields"] != nil {
+		t.Fatalf("fields = %#v, want null for a missing table", data["fields"])
+	}
+}
+
+func TestGetMySQLSchemaRequiresAUser(t *testing.T) {
+	host, port := harness.SplitHostPort(t, harness.MySQLSource)
+	body, err := json.Marshal(map[string]interface{}{
+		"sourceType": "mysql",
+		"connection": map[string]string{
+			"host": host, "port": port, "user": "", "password": "root",
+			"database": schemaSourceDB,
+		},
+		"tableName": "orders",
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	rec, resp := postSchema(t, body)
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Errorf("status = %d, want 500", rec.Code)
+	}
+	msg, _ := resp["message"].(string)
+	if msg == "" {
+		t.Errorf("message is empty: %s", rec.Body.String())
+	}
+}
+
+func TestGetMySQLSchemaReportsBadCredentials(t *testing.T) {
+	host, port := harness.SplitHostPort(t, harness.MySQLSource)
+	body, err := json.Marshal(map[string]interface{}{
+		"sourceType": "mysql",
+		"connection": map[string]string{
+			"host": host, "port": port, "user": "root", "password": "wrong-password",
+			"database": schemaSourceDB,
+		},
+		"tableName": "orders",
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	rec, resp := postSchema(t, body)
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Errorf("status = %d, want 500", rec.Code)
+	}
+	if resp["success"] != false {
+		t.Errorf("success = %v, want false", resp["success"])
+	}
+	// The supplied password must not be echoed back.
+	if bytes.Contains(rec.Body.Bytes(), []byte("wrong-password")) {
+		t.Errorf("the supplied password leaked into the response: %s", rec.Body.String())
+	}
+}
+
+// The seeded fixture tables from init.sql are readable, which also proves the
+// dispatch accepts the lower-cased type the rest of the codebase stores.
+func TestGetMySQLSchemaOnTheSeededTables(t *testing.T) {
+	for _, table := range []string{"orders", "users"} {
+		t.Run(table, func(t *testing.T) {
+			rec, resp := postSchema(t, schemaRequestBody(t, table))
+			if rec.Code != http.StatusOK {
+				t.Fatalf("status = %d (body: %s)", rec.Code, rec.Body.String())
+			}
+			if len(fieldsFrom(t, resp)) == 0 {
+				t.Errorf("%s returned no fields", table)
+			}
+		})
+	}
+}
+
+// ------------------------------------------------------------- MongoDB
+
+func openSchemaMongo(t *testing.T) *mongo.Client {
+	t.Helper()
+
+	uri := "mongodb://" + harness.MongoSource + "/?directConnection=true"
+	client, err := mongo.Connect(t.Context(), options.Client().ApplyURI(uri))
+	if err != nil {
+		t.Fatalf("connect %s: %v", harness.MongoSource, err)
+	}
+	if err := client.Ping(t.Context(), nil); err != nil {
+		t.Fatalf("ping %s: %v", harness.MongoSource, err)
+	}
+	t.Cleanup(func() { _ = client.Disconnect(context.Background()) })
+	return client
+}
+
+func mongoSchemaBody(t *testing.T, collection string) []byte {
+	t.Helper()
+
+	host, port := harness.SplitHostPort(t, harness.MongoSource)
+	body, err := json.Marshal(map[string]interface{}{
+		"sourceType": "mongodb",
+		"connection": map[string]string{
+			"host": host, "port": port, "database": schemaSourceDB,
+		},
+		"tableName": collection,
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return body
+}
+
+func TestGetMongoDBSchemaInfersFieldsFromDocuments(t *testing.T) {
+	collection := harness.UniqueName("mschema")
+	client := openSchemaMongo(t)
+	coll := client.Database(schemaSourceDB).Collection(collection)
+	t.Cleanup(func() { _ = coll.Drop(context.Background()) })
+
+	if _, err := coll.InsertOne(t.Context(), bson.M{
+		"name":   "alice",
+		"age":    int32(30),
+		"score":  4.5,
+		"active": true,
+		"tags":   bson.A{"a", "b"},
+		"address": bson.M{
+			"city": "Tokyo",
+			"geo":  bson.M{"lat": 35.6},
+		},
+	}); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	rec, resp := postSchema(t, mongoSchemaBody(t, collection))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d (body: %s)", rec.Code, rec.Body.String())
+	}
+
+	byName := map[string]map[string]interface{}{}
+	for _, f := range fieldsFrom(t, resp) {
+		byName[f["name"].(string)] = f
+	}
+
+	for name, wantType := range map[string]string{
+		"name":   "string",
+		"age":    "int",
+		"score":  "float",
+		"active": "bool",
+		// Not "array": the driver decodes a BSON array into primitive.A, which
+		// getMongoFieldType's `case []interface{}` does not match. See
+		// TestTheArrayBranchIsDeadForRealDocuments.
+		"tags":            "primitive.A",
+		"address":         "object",
+		"address.city":    "string",
+		"address.geo":     "object",
+		"address.geo.lat": "float",
+	} {
+		f, ok := byName[name]
+		if !ok {
+			t.Errorf("field %q is missing (got %v)", name, byName)
+			continue
+		}
+		if f["type"] != wantType {
+			t.Errorf("%s type = %v, want %v", name, f["type"], wantType)
+		}
+	}
+
+	if byName["_id"]["isPrimary"] != true {
+		t.Errorf("_id isPrimary = %v, want true", byName["_id"]["isPrimary"])
+	}
+	if byName["name"]["isPrimary"] != false {
+		t.Errorf("name isPrimary = %v, want false", byName["name"]["isPrimary"])
+	}
+}
+
+func TestGetMongoDBSchemaMergesFieldsAcrossDocuments(t *testing.T) {
+	collection := harness.UniqueName("mmerge")
+	client := openSchemaMongo(t)
+	coll := client.Database(schemaSourceDB).Collection(collection)
+	t.Cleanup(func() { _ = coll.Drop(context.Background()) })
+
+	// Different documents carry different fields; the union must be reported.
+	if _, err := coll.InsertMany(t.Context(), []interface{}{
+		bson.M{"a": "x"},
+		bson.M{"b": int32(1)},
+		bson.M{"c": true},
+	}); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	_, resp := postSchema(t, mongoSchemaBody(t, collection))
+
+	seen := map[string]bool{}
+	for _, f := range fieldsFrom(t, resp) {
+		seen[f["name"].(string)] = true
+	}
+	for _, want := range []string{"a", "b", "c", "_id"} {
+		if !seen[want] {
+			t.Errorf("field %q is missing: %v", want, seen)
+		}
+	}
+}
+
+// The sample is the last ten documents by natural order. A field that exists
+// only in older documents is invisible to the schema, so a collection whose
+// shape changed at some point reports only the newest shape — and the UI builds
+// table mappings from this list.
+func TestOnlyTheNewestTenDocumentsAreSampled(t *testing.T) {
+	collection := harness.UniqueName("msample")
+	client := openSchemaMongo(t)
+	coll := client.Database(schemaSourceDB).Collection(collection)
+	t.Cleanup(func() { _ = coll.Drop(context.Background()) })
+
+	// One old document with a field nothing else has.
+	if _, err := coll.InsertOne(t.Context(), bson.M{"legacy_field": "present only here"}); err != nil {
+		t.Fatalf("insert legacy: %v", err)
+	}
+	// Twenty newer documents without it.
+	var newer []interface{}
+	for i := 0; i < 20; i++ {
+		newer = append(newer, bson.M{"current_field": int32(i)})
+	}
+	if _, err := coll.InsertMany(t.Context(), newer); err != nil {
+		t.Fatalf("insert newer: %v", err)
+	}
+
+	_, resp := postSchema(t, mongoSchemaBody(t, collection))
+
+	seen := map[string]bool{}
+	for _, f := range fieldsFrom(t, resp) {
+		seen[f["name"].(string)] = true
+	}
+	if !seen["current_field"] {
+		t.Fatalf("current_field is missing, so the sample did not work at all: %v", seen)
+	}
+	if seen["legacy_field"] {
+		t.Fatalf("legacy_field was found — the sample appears to cover the whole collection now; assert the full schema instead")
+	}
+}
+
+// _id is present in every document and is reported with a Go type name
+// (T-081), because getMongoFieldType's switch has no case for ObjectID.
+func TestTheMongoIDTypeIsAGoTypeName(t *testing.T) {
+	collection := harness.UniqueName("mid")
+	client := openSchemaMongo(t)
+	coll := client.Database(schemaSourceDB).Collection(collection)
+	t.Cleanup(func() { _ = coll.Drop(context.Background()) })
+
+	if _, err := coll.InsertOne(t.Context(), bson.M{"n": int32(1)}); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	_, resp := postSchema(t, mongoSchemaBody(t, collection))
+
+	for _, f := range fieldsFrom(t, resp) {
+		if f["name"] == "_id" {
+			if f["type"] != "primitive.ObjectID" {
+				t.Fatalf("_id type = %v — ObjectID appears to be handled now; assert the database type instead", f["type"])
+			}
+			return
+		}
+	}
+	t.Fatal("_id was not reported at all")
+}
+
+// An empty MongoDB collection returns an empty array while an empty MySQL
+// result returns null (T-115), so the same endpoint answers with two different
+// shapes depending on the engine.
+func TestAnEmptyMongoCollectionReturnsAnArrayNotNull(t *testing.T) {
+	collection := harness.UniqueName("mempty")
+	client := openSchemaMongo(t)
+	coll := client.Database(schemaSourceDB).Collection(collection)
+	// Create the collection without documents.
+	if err := client.Database(schemaSourceDB).CreateCollection(t.Context(), collection); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	t.Cleanup(func() { _ = coll.Drop(context.Background()) })
+
+	rec, resp := postSchema(t, mongoSchemaBody(t, collection))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d (body: %s)", rec.Code, rec.Body.String())
+	}
+	data := resp["data"].(map[string]interface{})
+	if data["fields"] == nil {
+		t.Fatalf("fields = null — MongoDB now matches MySQL's shape; assert the unified shape instead")
+	}
+	if n := len(data["fields"].([]interface{})); n != 0 {
+		t.Errorf("fields has %d entries, want 0", n)
+	}
+}
+
+// A collection that does not exist behaves exactly like an empty one: 200 with
+// no fields. As with MySQL (T-115) a typo is indistinguishable from an empty
+// collection.
+func TestAMissingMongoCollectionLooksEmpty(t *testing.T) {
+	rec, resp := postSchema(t, mongoSchemaBody(t, "collection_that_does_not_exist"))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d — a missing collection appears to be reported now; assert the error instead", rec.Code)
+	}
+	if resp["success"] != true {
+		t.Fatalf("success = %v, want true", resp["success"])
+	}
+}
+
+func TestGetMongoDBSchemaReportsAnUnreachableHost(t *testing.T) {
+	body, err := json.Marshal(map[string]interface{}{
+		"sourceType": "mongodb",
+		"connection": map[string]string{
+			"host": "127.0.0.1", "port": "1", "database": schemaSourceDB,
+		},
+		"tableName": "anything",
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	rec, resp := postSchema(t, body)
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Errorf("status = %d, want 500", rec.Code)
+	}
+	if resp["success"] != false {
+		t.Errorf("success = %v, want false", resp["success"])
+	}
+}
+
+// Credentials are applied only when both the user and the password are
+// non-empty, so a user configured without a password connects anonymously
+// instead of failing or authenticating.
+func TestMongoCredentialsAreIgnoredWithoutAPassword(t *testing.T) {
+	collection := harness.UniqueName("mnopw")
+	client := openSchemaMongo(t)
+	coll := client.Database(schemaSourceDB).Collection(collection)
+	t.Cleanup(func() { _ = coll.Drop(context.Background()) })
+
+	if _, err := coll.InsertOne(t.Context(), bson.M{"n": int32(1)}); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	host, port := harness.SplitHostPort(t, harness.MongoSource)
+	body, err := json.Marshal(map[string]interface{}{
+		"sourceType": "mongodb",
+		"connection": map[string]string{
+			"host": host, "port": port, "database": schemaSourceDB,
+			"user": "someone", "password": "", // password omitted
+		},
+		"tableName": collection,
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	rec, resp := postSchema(t, body)
+
+	// The server has no authentication enabled, so an anonymous connection
+	// succeeds; a URI carrying the username would have been rejected.
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d — the username appears to be applied now; assert the authentication failure instead (body: %s)", rec.Code, rec.Body.String())
+	}
+	if resp["success"] != true {
+		t.Errorf("success = %v, want true", resp["success"])
+	}
+}
+
+// getMongoFieldType has a `case []interface{}: return "array"` branch, but the
+// driver decodes every BSON array into primitive.A — a named type that the case
+// does not match. The branch is therefore dead for real documents, and arrays
+// are always reported as the Go type name. The unit test that shows "array"
+// passes only because it constructs a plain []interface{} by hand.
+func TestTheArrayBranchIsDeadForRealDocuments(t *testing.T) {
+	collection := harness.UniqueName("marray")
+	client := openSchemaMongo(t)
+	coll := client.Database(schemaSourceDB).Collection(collection)
+	t.Cleanup(func() { _ = coll.Drop(context.Background()) })
+
+	if _, err := coll.InsertOne(t.Context(), bson.M{
+		"strings": bson.A{"a", "b"},
+		"numbers": bson.A{1, 2, 3},
+		"empty":   bson.A{},
+		"nested":  bson.A{bson.M{"k": "v"}},
+	}); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	_, resp := postSchema(t, mongoSchemaBody(t, collection))
+
+	for _, f := range fieldsFrom(t, resp) {
+		name := f["name"].(string)
+		switch name {
+		case "strings", "numbers", "empty", "nested":
+			if f["type"] != "primitive.A" {
+				t.Fatalf("%s type = %v — arrays appear to be recognised now; assert \"array\" instead", name, f["type"])
+			}
+		}
+	}
+}

--- a/pkg/api/monitor_handler_test.go
+++ b/pkg/api/monitor_handler_test.go
@@ -1,0 +1,505 @@
+package api
+
+import (
+	"database/sql"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+// useMonitorDB points the package at a throwaway SQLite file carrying the
+// tables the monitoring handlers read.
+func useMonitorDB(t *testing.T) *sql.DB {
+	t.Helper()
+
+	isolateCrontab(t)
+
+	path := filepath.Join(t.TempDir(), "sync.db")
+	t.Setenv("SYNC_DB_PATH", path)
+
+	conn, err := sql.Open("sqlite3", path)
+	if err != nil {
+		t.Fatalf("open temp sqlite: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+
+	const schema = `
+CREATE TABLE sync_tasks (
+    id               INTEGER PRIMARY KEY AUTOINCREMENT,
+    enable           INTEGER NOT NULL DEFAULT 1,
+    last_update_time DATETIME,
+    last_run_time    DATETIME,
+    config_json      TEXT NOT NULL
+);
+CREATE TABLE monitoring_log (
+    id             INTEGER PRIMARY KEY AUTOINCREMENT,
+    logged_at      DATETIME DEFAULT CURRENT_TIMESTAMP,
+    db_type        TEXT NOT NULL,
+    src_db         TEXT,
+    src_table      TEXT,
+    src_row_count  INTEGER,
+    tgt_db         TEXT,
+    tgt_table      TEXT,
+    tgt_row_count  INTEGER,
+    monitor_action TEXT,
+    sync_task_id   INTEGER
+);
+CREATE TABLE sync_log (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    log_time     DATETIME DEFAULT CURRENT_TIMESTAMP,
+    level        TEXT,
+    message      TEXT,
+    sync_task_id INTEGER
+);
+CREATE TABLE changestream_statistics (
+    id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    task_id         INTEGER NOT NULL,
+    collection_name VARCHAR(255) NOT NULL,
+    received        INTEGER DEFAULT 0,
+    executed        INTEGER DEFAULT 0,
+    pending         INTEGER DEFAULT 0,
+    errors          INTEGER DEFAULT 0,
+    inserted        INTEGER DEFAULT 0,
+    updated         INTEGER DEFAULT 0,
+    deleted         INTEGER DEFAULT 0,
+    last_updated    TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    created_at      TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(task_id, collection_name)
+);`
+	if _, err := conn.Exec(schema); err != nil {
+		t.Fatalf("create schema: %v", err)
+	}
+	return conn
+}
+
+func insertMonitoringRow(t *testing.T, conn *sql.DB, taskID int, loggedAt, table string, src, tgt int64) {
+	t.Helper()
+
+	if _, err := conn.Exec(`
+		INSERT INTO monitoring_log
+			(logged_at, db_type, src_db, src_table, src_row_count, tgt_db, tgt_table, tgt_row_count, monitor_action, sync_task_id)
+		VALUES (?, 'mysql', 'source_db', ?, ?, 'target_db', ?, ?, 'row_count_minutely', ?)`,
+		loggedAt, table, src, table, tgt, taskID); err != nil {
+		t.Fatalf("insert monitoring_log: %v", err)
+	}
+}
+
+func sqlNow(offset time.Duration) string {
+	return time.Now().UTC().Add(offset).Format("2006-01-02 15:04:05")
+}
+
+// ------------------------------------------------------------ SyncMonitor
+
+func TestSyncMonitorHandlerReportsTaskStatus(t *testing.T) {
+	conn := useMonitorDB(t)
+	if _, err := conn.Exec(`INSERT INTO sync_tasks (id, enable, config_json) VALUES (1, 1, '{}'), (2, 0, '{}')`); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	for _, tc := range []struct{ id, want string }{{"1", "Running"}, {"2", "Stopped"}} {
+		rec := httptest.NewRecorder()
+		serveWithURLParams(rec, httptest.NewRequest(http.MethodGet, "/sync/{id}/monitor", nil),
+			SyncMonitorHandler, map[string]string{"id": tc.id})
+
+		resp := decodeEnvelope(t, rec)
+		if resp["success"] != true {
+			t.Fatalf("task %s: %s", tc.id, rec.Body.String())
+		}
+		data := resp["data"].(map[string]interface{})
+		if data["status"] != tc.want {
+			t.Errorf("task %s: status = %v, want %v", tc.id, data["status"], tc.want)
+		}
+	}
+}
+
+func TestSyncMonitorHandlerOnAnUnknownTask(t *testing.T) {
+	useMonitorDB(t)
+
+	rec := httptest.NewRecorder()
+	serveWithURLParams(rec, httptest.NewRequest(http.MethodGet, "/sync/{id}/monitor", nil),
+		SyncMonitorHandler, map[string]string{"id": "999"})
+
+	resp := decodeEnvelope(t, rec)
+	if resp["success"] != false {
+		t.Errorf("success = %v, want false", resp["success"])
+	}
+}
+
+// progress, tps and delay are constants compiled into the handler. The
+// monitoring UI shows 85% progress, 500 tps and 0.2s delay for every task in
+// every state, including one that is stopped or has never run.
+func TestMonitorMetricsAreHardcoded(t *testing.T) {
+	conn := useMonitorDB(t)
+	if _, err := conn.Exec(`INSERT INTO sync_tasks (id, enable, config_json) VALUES (1, 0, '{}')`); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	serveWithURLParams(rec, httptest.NewRequest(http.MethodGet, "/sync/{id}/monitor", nil),
+		SyncMonitorHandler, map[string]string{"id": "1"})
+
+	data := decodeEnvelope(t, rec)["data"].(map[string]interface{})
+	if data["progress"] != float64(85) || data["tps"] != float64(500) || data["delay"] != 0.2 {
+		t.Fatalf("progress/tps/delay = %v/%v/%v — these appear to be measured now; assert the real values instead",
+			data["progress"], data["tps"], data["delay"])
+	}
+	if data["status"] != "Stopped" {
+		t.Errorf("status = %v, want Stopped", data["status"])
+	}
+}
+
+// ------------------------------------------------------------ SyncMetrics
+
+func metricsFor(t *testing.T, id, rangeStr string) map[string]interface{} {
+	t.Helper()
+
+	url := "/sync/{id}/metrics"
+	if rangeStr != "" {
+		url += "?range=" + rangeStr
+	}
+	rec := httptest.NewRecorder()
+	serveWithURLParams(rec, httptest.NewRequest(http.MethodGet, url, nil),
+		SyncMetricsHandler, map[string]string{"id": id})
+
+	resp := decodeEnvelope(t, rec)
+	if resp["success"] != true {
+		t.Fatalf("success = %v (body: %s)", resp["success"], rec.Body.String())
+	}
+	return resp["data"].(map[string]interface{})
+}
+
+func TestSyncMetricsBuildsThreeSeriesPerRow(t *testing.T) {
+	conn := useMonitorDB(t)
+	insertMonitoringRow(t, conn, 1, sqlNow(-30*time.Minute), "orders", 100, 90)
+
+	data := metricsFor(t, "1", "1h")
+	trend := data["rowCountTrend"].([]interface{})
+
+	if len(trend) != 3 {
+		t.Fatalf("rowCountTrend has %d points, want 3 (source/target/diff)", len(trend))
+	}
+	types := map[string]float64{}
+	for _, p := range trend {
+		m := p.(map[string]interface{})
+		types[m["type"].(string)] = m["value"].(float64)
+		if m["table"] != "orders" {
+			t.Errorf("table = %v, want orders", m["table"])
+		}
+	}
+	if types["source"] != 100 || types["target"] != 90 || types["diff"] != 10 {
+		t.Errorf("source/target/diff = %v/%v/%v, want 100/90/10", types["source"], types["target"], types["diff"])
+	}
+	if data["syncEventStats"] == nil {
+		t.Error("syncEventStats is missing")
+	}
+}
+
+func TestSyncMetricsDiffIsAbsolute(t *testing.T) {
+	conn := useMonitorDB(t)
+	// Target ahead of source, which happens when the target holds extra rows.
+	insertMonitoringRow(t, conn, 1, sqlNow(-10*time.Minute), "orders", 50, 80)
+
+	for _, p := range metricsFor(t, "1", "1h")["rowCountTrend"].([]interface{}) {
+		m := p.(map[string]interface{})
+		if m["type"] == "diff" && m["value"] != float64(30) {
+			t.Errorf("diff = %v, want the absolute value 30", m["value"])
+		}
+	}
+}
+
+func TestSyncMetricsFiltersByTask(t *testing.T) {
+	conn := useMonitorDB(t)
+	insertMonitoringRow(t, conn, 1, sqlNow(-10*time.Minute), "orders", 10, 10)
+	insertMonitoringRow(t, conn, 2, sqlNow(-10*time.Minute), "users", 20, 20)
+
+	for _, p := range metricsFor(t, "1", "1h")["rowCountTrend"].([]interface{}) {
+		if tbl := p.(map[string]interface{})["table"]; tbl != "orders" {
+			t.Errorf("task 1 returned a row for %v", tbl)
+		}
+	}
+}
+
+// Task id 0 is the "all tasks" view and prefixes the table with its task id.
+func TestSyncMetricsTaskZeroAggregatesEveryTask(t *testing.T) {
+	conn := useMonitorDB(t)
+	insertMonitoringRow(t, conn, 1, sqlNow(-10*time.Minute), "orders", 10, 10)
+	insertMonitoringRow(t, conn, 2, sqlNow(-10*time.Minute), "users", 20, 20)
+
+	seen := map[string]bool{}
+	for _, p := range metricsFor(t, "0", "1h")["rowCountTrend"].([]interface{}) {
+		seen[p.(map[string]interface{})["table"].(string)] = true
+	}
+	for _, want := range []string{"taskID:1_orders", "taskID:2_users"} {
+		if !seen[want] {
+			t.Errorf("%q is missing from the aggregate view: %v", want, seen)
+		}
+	}
+}
+
+func TestSyncMetricsWithNoRange(t *testing.T) {
+	conn := useMonitorDB(t)
+	insertMonitoringRow(t, conn, 1, sqlNow(-40*24*time.Hour), "orders", 1, 1)
+
+	// An empty range means no lower bound, so even a 40-day-old row is returned.
+	if n := len(metricsFor(t, "1", "")["rowCountTrend"].([]interface{})); n != 3 {
+		t.Errorf("rowCountTrend has %d points, want 3", n)
+	}
+}
+
+// When the requested window yields nothing, the handler silently re-runs the
+// query with the time filter removed and returns the entire history. A client
+// asking for the last hour and receiving month-old rows has no way to tell:
+// the response carries no indication that the window was abandoned.
+func TestAnEmptyWindowSilentlyReturnsTheWholeHistory(t *testing.T) {
+	conn := useMonitorDB(t)
+	// Nothing recent; one row far outside any supported range.
+	old := time.Now().UTC().AddDate(0, 0, -40).Format("2006-01-02 15:04:05")
+	insertMonitoringRow(t, conn, 1, old, "orders", 7, 7)
+
+	trend := metricsFor(t, "1", "1h")["rowCountTrend"].([]interface{})
+
+	if len(trend) == 0 {
+		t.Fatal("the fallback appears to have been removed — assert the empty window instead")
+	}
+	for _, p := range trend {
+		if v := p.(map[string]interface{})["value"]; v == float64(7) {
+			return // the 40-day-old row was served for a one-hour request
+		}
+	}
+	t.Fatalf("the out-of-range row was not returned: %v", trend)
+}
+
+// ------------------------------------------------------------- SyncLogs
+
+func TestSyncLogsHandlerReturnsRows(t *testing.T) {
+	conn := useMonitorDB(t)
+	for i, lvl := range []string{"info", "warn", "error"} {
+		if _, err := conn.Exec(
+			`INSERT INTO sync_log (log_time, level, message, sync_task_id) VALUES (?, ?, ?, 1)`,
+			sqlNow(-time.Duration(i+1)*time.Minute), lvl, "message "+lvl); err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+	}
+
+	rec := httptest.NewRecorder()
+	serveWithURLParams(rec, httptest.NewRequest(http.MethodGet, "/sync/{id}/logs?range=1h", nil),
+		SyncLogsHandler, map[string]string{"id": "1"})
+
+	resp := decodeEnvelope(t, rec)
+	if resp["success"] != true {
+		t.Fatalf("success = %v (body: %s)", resp["success"], rec.Body.String())
+	}
+	if resp["data"] == nil {
+		t.Fatal("data is nil")
+	}
+	if n := len(resp["data"].([]interface{})); n != 3 {
+		t.Errorf("data has %d entries, want 3", n)
+	}
+}
+
+func TestSyncLogsHandlerFiltersByLevel(t *testing.T) {
+	conn := useMonitorDB(t)
+	for _, lvl := range []string{"info", "warn", "error", "error"} {
+		if _, err := conn.Exec(
+			`INSERT INTO sync_log (log_time, level, message, sync_task_id) VALUES (?, ?, 'm', 1)`,
+			sqlNow(-time.Minute), lvl); err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+	}
+
+	rec := httptest.NewRecorder()
+	serveWithURLParams(rec, httptest.NewRequest(http.MethodGet, "/sync/{id}/logs?level=error&range=1h", nil),
+		SyncLogsHandler, map[string]string{"id": "1"})
+
+	resp := decodeEnvelope(t, rec)
+	data, _ := resp["data"].([]interface{})
+	for _, e := range data {
+		if lvl := e.(map[string]interface{})["level"]; lvl != "error" {
+			t.Errorf("level filter returned %v", lvl)
+		}
+	}
+	if len(data) != 2 {
+		t.Errorf("data has %d entries, want 2", len(data))
+	}
+}
+
+func TestSyncLogsHandlerSearches(t *testing.T) {
+	conn := useMonitorDB(t)
+	for _, msg := range []string{"connection refused", "sync completed", "connection reset"} {
+		if _, err := conn.Exec(
+			`INSERT INTO sync_log (log_time, level, message, sync_task_id) VALUES (?, 'info', ?, 1)`,
+			sqlNow(-time.Minute), msg); err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+	}
+
+	rec := httptest.NewRecorder()
+	serveWithURLParams(rec, httptest.NewRequest(http.MethodGet, "/sync/{id}/logs?search=connection&range=1h", nil),
+		SyncLogsHandler, map[string]string{"id": "1"})
+
+	data, _ := decodeEnvelope(t, rec)["data"].([]interface{})
+	if len(data) != 2 {
+		t.Errorf("search returned %d entries, want 2", len(data))
+	}
+}
+
+func TestSyncLogsHandlerReportsAMissingTable(t *testing.T) {
+	t.Setenv("SYNC_DB_PATH", filepath.Join(t.TempDir(), "empty.db"))
+
+	rec := httptest.NewRecorder()
+	serveWithURLParams(rec, httptest.NewRequest(http.MethodGet, "/sync/{id}/logs", nil),
+		SyncLogsHandler, map[string]string{"id": "1"})
+
+	if resp := decodeEnvelope(t, rec); resp["success"] != false {
+		t.Errorf("success = %v, want false", resp["success"])
+	}
+}
+
+// -------------------------------------------------- ChangeStreamsStatus
+
+func TestChangeStreamsStatusHandlerAggregates(t *testing.T) {
+	conn := useMonitorDB(t)
+	rows := []struct {
+		taskID                            int
+		coll                              string
+		received, executed, pending, errs int
+		inserted, updated, deleted        int
+	}{
+		{1, "source_db.orders", 100, 90, 10, 1, 50, 30, 10},
+		{1, "source_db.users", 40, 40, 0, 0, 20, 15, 5},
+		{2, "source_db.audit", 10, 5, 5, 2, 5, 0, 0},
+	}
+	for _, r := range rows {
+		if _, err := conn.Exec(`
+			INSERT INTO changestream_statistics
+				(task_id, collection_name, received, executed, pending, errors, inserted, updated, deleted)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			r.taskID, r.coll, r.received, r.executed, r.pending, r.errs, r.inserted, r.updated, r.deleted); err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+	}
+
+	rec := httptest.NewRecorder()
+	ChangeStreamsStatusHandler(rec, httptest.NewRequest(http.MethodGet, "/changestreams/status", nil))
+
+	resp := decodeEnvelope(t, rec)
+	if resp["success"] != true {
+		t.Fatalf("success = %v (body: %s)", resp["success"], rec.Body.String())
+	}
+	body, err := json.Marshal(resp["data"])
+	if err != nil {
+		t.Fatalf("marshal data: %v", err)
+	}
+	// The aggregate must account for every seeded row.
+	for _, want := range []string{"source_db.orders", "source_db.users", "source_db.audit"} {
+		if !strings.Contains(string(body), want) {
+			t.Errorf("%q is missing from the response: %s", want, body)
+		}
+	}
+}
+
+func TestChangeStreamsStatusHandlerOnAnEmptyTable(t *testing.T) {
+	useMonitorDB(t)
+
+	rec := httptest.NewRecorder()
+	ChangeStreamsStatusHandler(rec, httptest.NewRequest(http.MethodGet, "/changestreams/status", nil))
+
+	if resp := decodeEnvelope(t, rec); resp["success"] != true {
+		t.Errorf("success = %v, want true on an empty table", resp["success"])
+	}
+}
+
+func TestChangeStreamsStatusHandlerReportsAMissingTable(t *testing.T) {
+	t.Setenv("SYNC_DB_PATH", filepath.Join(t.TempDir(), "empty.db"))
+
+	rec := httptest.NewRecorder()
+	ChangeStreamsStatusHandler(rec, httptest.NewRequest(http.MethodGet, "/changestreams/status", nil))
+
+	if resp := decodeEnvelope(t, rec); resp["success"] != false {
+		t.Errorf("success = %v, want false", resp["success"])
+	}
+}
+
+// -------------------------------------------------------- SyncTables
+
+func TestSyncTablesHandlerSummarisesToday(t *testing.T) {
+	conn := useMonitorDB(t)
+	today := time.Now().UTC().Format("2006-01-02")
+	insertMonitoringRow(t, conn, 1, today+" 01:00:00", "orders", 100, 100)
+	insertMonitoringRow(t, conn, 1, today+" 02:00:00", "orders", 180, 175)
+
+	rec := httptest.NewRecorder()
+	serveWithURLParams(rec, httptest.NewRequest(http.MethodGet, "/sync/{id}/tables", nil),
+		SyncTablesHandler, map[string]string{"id": "1"})
+
+	resp := decodeEnvelope(t, rec)
+	if resp["success"] != true {
+		t.Fatalf("success = %v (body: %s)", resp["success"], rec.Body.String())
+	}
+	body, _ := json.Marshal(resp["data"])
+	if !strings.Contains(string(body), "orders") {
+		t.Errorf("orders is missing: %s", body)
+	}
+	// synced_today = MAX(tgt) - MIN(tgt) = 175 - 100
+	if !strings.Contains(string(body), "75") {
+		t.Errorf("the daily delta of 75 is missing: %s", body)
+	}
+}
+
+func TestSyncTablesHandlerIgnoresOtherDays(t *testing.T) {
+	conn := useMonitorDB(t)
+	yesterday := time.Now().UTC().AddDate(0, 0, -1).Format("2006-01-02")
+	insertMonitoringRow(t, conn, 1, yesterday+" 12:00:00", "orders", 999, 999)
+
+	rec := httptest.NewRecorder()
+	serveWithURLParams(rec, httptest.NewRequest(http.MethodGet, "/sync/{id}/tables", nil),
+		SyncTablesHandler, map[string]string{"id": "1"})
+
+	body, _ := json.Marshal(decodeEnvelope(t, rec)["data"])
+	if strings.Contains(string(body), "999") {
+		t.Errorf("yesterday's row leaked into today's summary: %s", body)
+	}
+}
+
+// The window is built from UTC calendar days while the rest of the API reports
+// JST. Between 00:00 and 09:00 JST the "today" summary therefore covers the
+// previous JST day, and rows from the current JST morning are excluded.
+func TestTheDailySummaryWindowIsUTCNotJST(t *testing.T) {
+	conn := useMonitorDB(t)
+
+	nowUTC := time.Now().UTC()
+	jst := nowUTC.In(time.FixedZone("JST", 9*60*60))
+	if nowUTC.Format("2006-01-02") == jst.Format("2006-01-02") {
+		t.Skip("UTC and JST are on the same calendar day right now")
+	}
+
+	// A row stamped for the current JST day but the next UTC day.
+	insertMonitoringRow(t, conn, 1, jst.Format("2006-01-02")+" 00:30:00", "orders", 5, 5)
+
+	rec := httptest.NewRecorder()
+	serveWithURLParams(rec, httptest.NewRequest(http.MethodGet, "/sync/{id}/tables", nil),
+		SyncTablesHandler, map[string]string{"id": "1"})
+
+	body, _ := json.Marshal(decodeEnvelope(t, rec)["data"])
+	if strings.Contains(string(body), "orders") {
+		t.Fatalf("the window appears to use JST now — assert the JST day instead: %s", body)
+	}
+}
+
+func TestSyncTablesHandlerReportsAMissingTable(t *testing.T) {
+	t.Setenv("SYNC_DB_PATH", filepath.Join(t.TempDir(), "empty.db"))
+
+	rec := httptest.NewRecorder()
+	serveWithURLParams(rec, httptest.NewRequest(http.MethodGet, "/sync/{id}/tables", nil),
+		SyncTablesHandler, map[string]string{"id": "1"})
+
+	if resp := decodeEnvelope(t, rec); resp["success"] != false {
+		t.Errorf("success = %v, want false", resp["success"])
+	}
+}

--- a/pkg/api/open_endpoints_test.go
+++ b/pkg/api/open_endpoints_test.go
@@ -1,0 +1,364 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// The router installs no middleware (see TestTheRouterInstallsNoMiddleware)
+// and most handlers perform no credential check of their own, so those
+// endpoints are reachable by anyone who can reach the port.
+//
+// The tests below record that state. They are NOT a specification: the
+// permission model for this API is undecided, and every one of them must be
+// replaced with a real authorization assertion once it is settled. Each asserts
+// only that no 401 or 403 is returned — deliberately not a specific success
+// code, so it pins "no credentials required" and nothing else.
+//
+// See T-072 in docs/TEST_FINDINGS.md.
+
+// unauthenticated runs a handler with no Authorization header and no session,
+// and fails if the handler rejected the caller on credentials.
+func unauthenticated(t *testing.T, name string, h http.HandlerFunc, req *http.Request, params map[string]string) *httptest.ResponseRecorder {
+	t.Helper()
+
+	resetSessionGlobals(t)
+
+	rec := httptest.NewRecorder()
+	if params != nil {
+		serveWithURLParams(rec, req, h, params)
+	} else {
+		h(rec, req)
+	}
+
+	if rec.Code == http.StatusUnauthorized || rec.Code == http.StatusForbidden {
+		t.Fatalf("%s now returns %d without credentials — the permission model appears to have been implemented; replace this with the intended authorization assertion", name, rec.Code)
+	}
+	return rec
+}
+
+func jsonRequest(method, path, body string) *http.Request {
+	req := httptest.NewRequest(method, path, strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	return req
+}
+
+// ------------------------------------------------- task management is open
+
+func TestTaskManagementIsReachableWithoutCredentials(t *testing.T) {
+	cases := []struct {
+		name    string
+		handler http.HandlerFunc
+		req     *http.Request
+		params  map[string]string
+	}{
+		{"GET /api/sync", SyncListHandler, jsonRequest(http.MethodGet, "/sync", ""), nil},
+		{"POST /api/sync", SyncCreateHandler, jsonRequest(http.MethodPost, "/sync",
+			`{"taskName":"injected","type":"mysql","sourceConn":{"host":"h"},"targetConn":{"host":"h"}}`), nil},
+		{"PUT /api/sync/{id}", SyncUpdateHandler, jsonRequest(http.MethodPut, "/sync/{id}",
+			`{"taskName":"renamed"}`), map[string]string{"id": "1"}},
+		{"DELETE /api/sync/{id}", SyncDeleteHandler, jsonRequest(http.MethodDelete, "/sync/{id}", ""),
+			map[string]string{"id": "1"}},
+		{"PUT /api/sync/{id}/start", SyncStartHandler, jsonRequest(http.MethodPut, "/sync/{id}/start", ""),
+			map[string]string{"id": "1"}},
+		{"PUT /api/sync/{id}/stop", SyncStopHandler, jsonRequest(http.MethodPut, "/sync/{id}/stop", ""),
+			map[string]string{"id": "1"}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			useTempTaskDB(t)
+			unauthenticated(t, tc.name, tc.handler, tc.req, tc.params)
+		})
+	}
+}
+
+// An unauthenticated caller can create a sync task, and the task is persisted.
+// Task configuration is what getRowCountWithContext interpolates into SQL
+// (T-098), so this is also the entry point for that.
+func TestAnUnauthenticatedCallerCanPersistASyncTask(t *testing.T) {
+	conn := useTempTaskDB(t)
+	resetSessionGlobals(t)
+
+	rec := httptest.NewRecorder()
+	SyncCreateHandler(rec, jsonRequest(http.MethodPost, "/sync",
+		`{"taskName":"created without credentials","type":"mysql",
+		  "sourceConn":{"host":"h","port":"3306","user":"u","password":"p","database":"d"},
+		  "targetConn":{"host":"h","port":"3306","user":"u","password":"p","database":"d"},
+		  "mappings":[]}`))
+
+	if rec.Code == http.StatusUnauthorized || rec.Code == http.StatusForbidden {
+		t.Fatalf("POST /api/sync now returns %d — replace this with the intended authorization assertion", rec.Code)
+	}
+
+	var n int
+	if err := conn.QueryRow("SELECT COUNT(*) FROM sync_tasks").Scan(&n); err != nil {
+		t.Fatalf("count sync_tasks: %v", err)
+	}
+	if n == 0 {
+		t.Fatalf("the task was not persisted (body: %s) — creation appears to be gated now", rec.Body.String())
+	}
+}
+
+// ---------------------------------------------- user management is open
+
+func TestUserManagementIsReachableWithoutCredentials(t *testing.T) {
+	cases := []struct {
+		name    string
+		handler http.HandlerFunc
+		req     *http.Request
+	}{
+		{"GET /api/users", GetUsersHandler, jsonRequest(http.MethodGet, "/users", "")},
+		{"PUT /api/users/access", UpdateUserAccessHandler, jsonRequest(http.MethodPut, "/users/access",
+			`{"userId":"u1","access":"admin"}`)},
+		{"DELETE /api/users", DeleteUserHandler, jsonRequest(http.MethodDelete, "/users", `{"userId":"u1"}`)},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			useTempDB(t)
+			unauthenticated(t, tc.name, tc.handler, tc.req, nil)
+		})
+	}
+}
+
+// GET /api/users needs no credentials and returns every account's identity and
+// privilege level. It does at least strip the password (see
+// TestGetUsersHandlerDoesNotLeakPasswords).
+func TestTheUserDirectoryIsPubliclyReadable(t *testing.T) {
+	conn := useTempDB(t)
+	insertUser(t, conn, "admin", "s3cret", "Administrator", "admin")
+	insertUser(t, conn, "bob", "hunter2", "Bob", "guest")
+	resetSessionGlobals(t)
+
+	rec := httptest.NewRecorder()
+	GetUsersHandler(rec, jsonRequest(http.MethodGet, "/users", ""))
+
+	if rec.Code == http.StatusUnauthorized || rec.Code == http.StatusForbidden {
+		t.Fatalf("GET /api/users now returns %d — replace this with the intended authorization assertion", rec.Code)
+	}
+
+	body := rec.Body.String()
+	if !strings.Contains(body, "Administrator") || !strings.Contains(body, "admin") {
+		t.Fatalf("the directory no longer lists accounts — assert the new response instead: %s", body)
+	}
+	// Passwords must not be there regardless of the permission model.
+	for _, secret := range []string{"s3cret", "hunter2"} {
+		if strings.Contains(body, secret) {
+			t.Errorf("a password leaked into the response: %s", body)
+		}
+	}
+}
+
+// An unauthenticated caller can grant itself admin.
+func TestAnUnauthenticatedCallerCanGrantAdmin(t *testing.T) {
+	conn := useTempDB(t)
+	insertUser(t, conn, "bob", "pw", "Bob", "guest")
+	// UpdateUserAccessHandler looks users up by the userId column.
+	const userID = "google_20260821000000"
+	if _, err := conn.Exec("UPDATE users SET userId = ? WHERE username = 'bob'", userID); err != nil {
+		t.Fatalf("set userId: %v", err)
+	}
+	resetSessionGlobals(t)
+
+	rec := httptest.NewRecorder()
+	UpdateUserAccessHandler(rec, jsonRequest(http.MethodPut, "/users/access",
+		`{"userId":"`+userID+`","access":"admin"}`))
+
+	if rec.Code == http.StatusUnauthorized || rec.Code == http.StatusForbidden {
+		t.Fatalf("PUT /api/users/access now returns %d — replace this with the intended authorization assertion", rec.Code)
+	}
+
+	var access string
+	if err := conn.QueryRow("SELECT access FROM users WHERE username='bob'").Scan(&access); err != nil {
+		t.Fatalf("read access: %v", err)
+	}
+	if access != "admin" {
+		t.Fatalf("access = %q — the privilege change appears to be gated now; assert the rejection instead (body: %s)", access, rec.Body.String())
+	}
+}
+
+// ------------------------------------------------ backup control is open
+
+func TestBackupControlIsReachableWithoutCredentials(t *testing.T) {
+	cases := []struct {
+		name    string
+		handler http.HandlerFunc
+		req     *http.Request
+		params  map[string]string
+	}{
+		{"GET /api/backup", BackupListHandler, jsonRequest(http.MethodGet, "/backup", ""), nil},
+		{"POST /api/backup", BackupCreateHandler, jsonRequest(http.MethodPost, "/backup",
+			`{"name":"injected","sourceType":"mysql","schedule":"0 3 * * *"}`), nil},
+		{"DELETE /api/backup/{id}", BackupDeleteHandler, jsonRequest(http.MethodDelete, "/backup/{id}", ""),
+			map[string]string{"id": "1"}},
+		{"PUT /api/backup/{id}/pause", BackupPauseHandler, jsonRequest(http.MethodPut, "/backup/{id}/pause", ""),
+			map[string]string{"id": "1"}},
+		{"PUT /api/backup/{id}/resume", BackupResumeHandler, jsonRequest(http.MethodPut, "/backup/{id}/resume", ""),
+			map[string]string{"id": "1"}},
+		{"GET /api/backup/status/{taskId}", BackupStatusHandler,
+			jsonRequest(http.MethodGet, "/backup/status/{taskId}", ""), map[string]string{"taskId": "unknown"}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			useTempTaskDB(t)
+			resetTaskStatus(t)
+			unauthenticated(t, tc.name, tc.handler, tc.req, tc.params)
+		})
+	}
+}
+
+// ------------------------------------------ database access endpoints
+
+// POST /api/sql/execute runs caller-supplied SQL against a task's source or
+// target database and requires no credentials. Whether this endpoint should
+// exist at all is one of the open permission-model questions.
+func TestExecuteSQLIsReachableWithoutCredentials(t *testing.T) {
+	useTempTaskDB(t)
+
+	rec := unauthenticated(t, "POST /api/sql/execute", ExecuteSQLHandler,
+		jsonRequest(http.MethodPost, "/sql/execute", `{"taskId":1,"sql":"SELECT 1","target":false}`), nil)
+
+	// With no such task the handler fails on the lookup rather than on
+	// authorization, which is the point being recorded.
+	if rec.Code == http.StatusOK {
+		t.Logf("the handler accepted the request outright: %s", rec.Body.String())
+	}
+}
+
+// POST /api/test-connection probes an arbitrary host and port supplied by the
+// caller and reports whether it answered, with no credentials required.
+func TestConnectionProbeIsReachableWithoutCredentials(t *testing.T) {
+	rec := unauthenticated(t, "POST /api/test-connection", TestConnectionHandler,
+		jsonRequest(http.MethodPost, "/test-connection",
+			`{"dbType":"mysql","host":"127.0.0.1","port":"1","user":"u","password":"p","database":"d"}`), nil)
+
+	if rec.Code == http.StatusOK {
+		t.Logf("the probe reported success: %s", rec.Body.String())
+	}
+}
+
+// POST /api/tables/schema reads a schema from any reachable database using
+// credentials the caller supplies, with no authentication of the caller.
+func TestSchemaReadIsReachableWithoutCredentials(t *testing.T) {
+	unauthenticated(t, "POST /api/tables/schema", GetTableSchemaHandler,
+		jsonRequest(http.MethodPost, "/tables/schema",
+			`{"sourceType":"mysql","connection":{"host":"127.0.0.1","port":"1","user":"u","password":"p","database":"d"},"tableName":"t"}`), nil)
+}
+
+// ------------------------------------------------ monitoring is open
+
+func TestMonitoringIsReachableWithoutCredentials(t *testing.T) {
+	cases := []struct {
+		name    string
+		handler http.HandlerFunc
+		req     *http.Request
+		params  map[string]string
+	}{
+		{"GET /api/sync/{id}/monitor", SyncMonitorHandler,
+			jsonRequest(http.MethodGet, "/sync/{id}/monitor", ""), map[string]string{"id": "1"}},
+		{"GET /api/sync/{id}/metrics", SyncMetricsHandler,
+			jsonRequest(http.MethodGet, "/sync/{id}/metrics", ""), map[string]string{"id": "1"}},
+		{"GET /api/sync/{id}/logs", SyncLogsHandler,
+			jsonRequest(http.MethodGet, "/sync/{id}/logs", ""), map[string]string{"id": "1"}},
+		{"GET /api/sync/{id}/tables", SyncTablesHandler,
+			jsonRequest(http.MethodGet, "/sync/{id}/tables", ""), map[string]string{"id": "1"}},
+		{"GET /api/changestreams/status", ChangeStreamsStatusHandler,
+			jsonRequest(http.MethodGet, "/changestreams/status", ""), nil},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			useMonitorDB(t)
+			unauthenticated(t, tc.name, tc.handler, tc.req, tc.params)
+		})
+	}
+}
+
+// GET /api/oauth/{provider}/config is readable without credentials while its
+// PUT counterpart requires an admin token — the two halves of the same
+// resource disagree.
+func TestOAuthConfigReadIsOpenWhileWriteIsGated(t *testing.T) {
+	conn := useTempDB(t)
+	if _, err := conn.Exec(
+		`INSERT INTO auth_configs (provider, config_json, enabled) VALUES ('google', ?, 1)`,
+		`{"clientId":"cid","clientSecret":"csecret"}`); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	// Read: no credentials needed. The provider must come from the query
+	// string, not the path — see TestTheOAuthPathParameterIsIgnored.
+	rec := unauthenticated(t, "GET /api/oauth/{provider}/config", GetOAuthConfigHandler,
+		jsonRequest(http.MethodGet, "/oauth/google/config?provider=google", ""), nil)
+	if !strings.Contains(rec.Body.String(), "cid") {
+		t.Errorf("the config was not returned: %s", rec.Body.String())
+	}
+
+	// Write: admin token required, so the asymmetry is real.
+	resetSessionGlobals(t)
+	wrec := httptest.NewRecorder()
+	UpdateOAuthConfigHandler(wrec, jsonRequest(http.MethodPut, "/oauth/google/config?provider=google", `{}`))
+	if wrec.Code != http.StatusUnauthorized {
+		t.Fatalf("PUT returned %d, want 401 — the two halves appear to agree now; assert the shared policy instead", wrec.Code)
+	}
+}
+
+// The client secret is served to unauthenticated callers along with the rest of
+// the OAuth configuration.
+func TestTheOAuthClientSecretIsPubliclyReadable(t *testing.T) {
+	conn := useTempDB(t)
+	if _, err := conn.Exec(
+		`INSERT INTO auth_configs (provider, config_json, enabled) VALUES ('google', ?, 1)`,
+		`{"clientId":"cid","clientSecret":"the-client-secret"}`); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	resetSessionGlobals(t)
+
+	rec := httptest.NewRecorder()
+	GetOAuthConfigHandler(rec, jsonRequest(http.MethodGet, "/oauth/google/config?provider=google", ""))
+
+	if !strings.Contains(rec.Body.String(), "the-client-secret") {
+		t.Fatalf("the client secret is no longer served — it appears to be redacted; assert the redaction instead (body: %s)", rec.Body.String())
+	}
+}
+
+// auth_handler.go imports github.com/go-chi/chi (v1) while router.go registers
+// its routes with github.com/go-chi/chi/v5. chi v1's URLParam reads a route
+// context key that v5 never populates, so every path parameter read in
+// auth_handler.go is empty. Both OAuth handlers happen to fall back to a query
+// string, so the route as documented — /api/oauth/{provider}/config — answers
+// 400 unless the caller also repeats the provider as ?provider=.
+func TestTheOAuthPathParameterIsIgnored(t *testing.T) {
+	conn := useTempDB(t)
+	if _, err := conn.Exec(
+		`INSERT INTO auth_configs (provider, config_json, enabled) VALUES ('google', ?, 1)`,
+		`{"clientId":"cid"}`); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	resetSessionGlobals(t)
+
+	router := NewRouter()
+
+	// The documented route shape.
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/oauth/google/config", nil))
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("GET /oauth/google/config returned %d — the path parameter appears to work now (chi versions unified?); assert the config instead", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), "missing provider parameter") {
+		t.Errorf("body = %s, want the missing-provider error", rec.Body.String())
+	}
+
+	// The same request with the provider repeated in the query string.
+	rec = httptest.NewRecorder()
+	router.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/oauth/google/config?provider=google", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("the query-string form returned %d, want 200: %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "cid") {
+		t.Errorf("the config was not returned: %s", rec.Body.String())
+	}
+}

--- a/pkg/api/response_test.go
+++ b/pkg/api/response_test.go
@@ -1,0 +1,260 @@
+package api
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestWriteJSONSetsContentTypeAndBody(t *testing.T) {
+	rec := httptest.NewRecorder()
+
+	writeJSON(rec, map[string]interface{}{"success": true, "count": 3})
+
+	if got := rec.Header().Get("Content-Type"); got != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json", got)
+	}
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200", rec.Code)
+	}
+
+	var body map[string]interface{}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("body is not JSON: %v (%q)", err, rec.Body.String())
+	}
+	if body["success"] != true {
+		t.Errorf("success = %v, want true", body["success"])
+	}
+	if body["count"] != float64(3) {
+		t.Errorf("count = %v, want 3", body["count"])
+	}
+}
+
+func TestWriteJSONEncodesNil(t *testing.T) {
+	rec := httptest.NewRecorder()
+
+	writeJSON(rec, nil)
+
+	if got := rec.Body.String(); got != "null\n" {
+		t.Errorf("body = %q, want %q", got, "null\n")
+	}
+}
+
+func TestErrorJSONShape(t *testing.T) {
+	rec := httptest.NewRecorder()
+
+	errorJSON(rec, "failed to open the task", errors.New("no such file"))
+
+	var body map[string]interface{}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("body is not JSON: %v (%q)", err, rec.Body.String())
+	}
+	if body["success"] != false {
+		t.Errorf("success = %v, want false", body["success"])
+	}
+	if body["error"] != "failed to open the task" {
+		t.Errorf("error = %v", body["error"])
+	}
+	if body["detail"] != "no such file" {
+		t.Errorf("detail = %v", body["detail"])
+	}
+}
+
+// errorJSON reports failure in the body but leaves the status line untouched,
+// so every error this helper produces is served as 200 OK. A client that
+// branches on the status code — a load balancer, a probe, a generated SDK —
+// sees a successful request. If this ever starts returning a 4xx/5xx the
+// helper has been fixed; assert the intended status instead.
+func TestErrorJSONStillReturnsHTTP200(t *testing.T) {
+	rec := httptest.NewRecorder()
+
+	errorJSON(rec, "database is unreachable", errors.New("connection refused"))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("errorJSON now returns %d — it appears to be fixed; assert the intended status instead", rec.Code)
+	}
+}
+
+// errorJSON dereferences its error argument unconditionally, so a caller that
+// reports a failure without one takes down the request goroutine.
+func TestErrorJSONPanicsOnNilError(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Fatal("errorJSON no longer panics on a nil error — it appears to be fixed; assert the emitted detail instead")
+		}
+	}()
+
+	errorJSON(httptest.NewRecorder(), "something went wrong", nil)
+}
+
+func TestTimeNowStrIsUTCSQLFormat(t *testing.T) {
+	got := timeNowStr()
+
+	parsed, err := time.Parse("2006-01-02 15:04:05", got)
+	if err != nil {
+		t.Fatalf("timeNowStr() = %q, not a SQL datetime: %v", got, err)
+	}
+	if delta := time.Since(parsed.UTC()); delta < -2*time.Second || delta > 2*time.Second {
+		t.Errorf("timeNowStr() = %q, %v away from now — it is probably not UTC", got, delta)
+	}
+}
+
+func TestConvertTimeToJST(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"sql format shifts by nine hours", "2026-08-21 00:30:00", "2026-08-21 09:30:00"},
+		{"sql format crosses the date line", "2026-08-21 20:00:00", "2026-08-22 05:00:00"},
+		{"rfc3339 utc is normalised to sql format", "2026-08-21T00:30:00Z", "2026-08-21 09:30:00"},
+		{"rfc3339 with an offset is respected", "2026-08-21T00:30:00+02:00", "2026-08-21 07:30:00"},
+		{"an empty string stays empty", "", ""},
+		{"an unparseable string is passed through", "not a time", "not a time"},
+		{"a date without a clock is passed through", "2026-08-21", "2026-08-21"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := convertTimeToJST(tc.input); got != tc.want {
+				t.Errorf("convertTimeToJST(%q) = %q, want %q", tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
+// convertTimeToJST treats a naive SQL timestamp as UTC. Any caller that stores
+// local time in that column gets a second, silent nine-hour shift.
+func TestConvertTimeToJSTAssumesTheInputIsUTC(t *testing.T) {
+	const alreadyJST = "2026-08-21 09:30:00"
+
+	if got := convertTimeToJST(alreadyJST); got != "2026-08-21 18:30:00" {
+		t.Fatalf("convertTimeToJST(%q) = %q — the UTC assumption appears to have changed", alreadyJST, got)
+	}
+}
+
+func TestConvertToJST(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"rfc3339 utc", "2026-08-21T00:30:00Z", "2026-08-21T09:30+09:00"},
+		{"rfc3339 with an offset", "2026-08-21T00:30:00+02:00", "2026-08-21T07:30+09:00"},
+		{"seconds are dropped", "2026-08-21T00:30:45Z", "2026-08-21T09:30+09:00"},
+		{"an empty string is passed through", "", ""},
+		{"a sql timestamp is not understood", "2026-08-21 00:30:00", "2026-08-21 00:30:00"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := convertToJST(tc.input); got != tc.want {
+				t.Errorf("convertToJST(%q) = %q, want %q", tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
+// The package carries two JST converters that disagree on both the accepted
+// input and the emitted layout: convertToJST (monitor_handler.go) takes
+// RFC3339 and drops seconds, convertTimeToJST (sync_handler.go) takes a SQL
+// timestamp and keeps them. Each silently passes through what the other
+// handles, so the format a field arrives in depends on which handler served it.
+func TestTheTwoJSTConvertersDisagree(t *testing.T) {
+	const rfc = "2026-08-21T00:30:00Z"
+	const sqlTS = "2026-08-21 00:30:00"
+
+	if convertToJST(rfc) == convertTimeToJST(rfc) {
+		t.Fatal("the two converters now agree on RFC3339 — they appear to have been unified")
+	}
+	if convertToJST(sqlTS) != sqlTS {
+		t.Fatal("convertToJST now understands SQL timestamps — the converters appear to have been unified")
+	}
+	if convertTimeToJST(rfc) == rfc {
+		t.Fatal("convertTimeToJST no longer understands RFC3339 — the converters appear to have been unified")
+	}
+}
+
+func TestParseRangeToSince(t *testing.T) {
+	tests := []struct {
+		input string
+		back  time.Duration
+	}{
+		{"1h", time.Hour},
+		{"2h", 2 * time.Hour},
+		{"3h", 3 * time.Hour},
+		{"6h", 6 * time.Hour},
+		{"12h", 12 * time.Hour},
+		{"1d", 24 * time.Hour},
+		{"2d", 48 * time.Hour},
+		{"7d", 7 * 24 * time.Hour},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.input, func(t *testing.T) {
+			got := parseRangeToSince(tc.input)
+			want := time.Now().UTC().Add(-tc.back)
+			if delta := got.Sub(want); delta < -2*time.Second || delta > 2*time.Second {
+				t.Errorf("parseRangeToSince(%q) = %v, want ~%v (off by %v)", tc.input, got, want, delta)
+			}
+		})
+	}
+}
+
+func TestParseRangeToSinceIsCaseInsensitive(t *testing.T) {
+	lower := parseRangeToSince("12h")
+	upper := parseRangeToSince("12H")
+
+	if delta := upper.Sub(lower); delta < -2*time.Second || delta > 2*time.Second {
+		t.Errorf("parseRangeToSince(\"12H\") = %v, parseRangeToSince(\"12h\") = %v", upper, lower)
+	}
+}
+
+func TestParseRangeToSinceEmptyIsTheZeroTime(t *testing.T) {
+	if got := parseRangeToSince(""); !got.IsZero() {
+		t.Errorf("parseRangeToSince(\"\") = %v, want the zero time", got)
+	}
+}
+
+// An unrecognised range is not rejected and does not fall back to a documented
+// default — it silently becomes a ten-hour window, a value that appears
+// nowhere in the accepted set. A caller asking for "30m" or "24h" (neither is
+// in the switch) gets ten hours of data and no indication anything was wrong.
+func TestUnknownRangesSilentlyBecomeTenHours(t *testing.T) {
+	for _, input := range []string{"30m", "24h", "4h", "banana", "-1h", "0"} {
+		got := parseRangeToSince(input)
+		want := time.Now().UTC().Add(-10 * time.Hour)
+		if delta := got.Sub(want); delta < -2*time.Second || delta > 2*time.Second {
+			t.Fatalf("parseRangeToSince(%q) = %v, no longer the undocumented 10h default — it appears to be fixed; assert the new behaviour instead", input, got)
+		}
+	}
+}
+
+// calculateNextBackupTime takes a cron expression and never reads it. Every
+// backup task reports the same next run — twenty-four hours from now —
+// regardless of its actual schedule, so the value shown in the UI is unrelated
+// to when the job will fire.
+func TestNextBackupTimeIgnoresTheCronExpression(t *testing.T) {
+	schedules := []string{
+		"*/5 * * * *", // every five minutes
+		"0 3 * * *",   // 03:00 daily
+		"0 0 1 * *",   // monthly
+		"",            // not a schedule at all
+		"not a cron",  // malformed
+	}
+
+	want := time.Now().UTC().Add(24 * time.Hour).Format("2006-01-02 15:04:05")
+	for _, expr := range schedules {
+		got := calculateNextBackupTime(expr)
+		parsed, err := time.Parse("2006-01-02 15:04:05", got)
+		if err != nil {
+			t.Fatalf("calculateNextBackupTime(%q) = %q, not a SQL datetime: %v", expr, got, err)
+		}
+		if delta := parsed.Sub(time.Now().UTC().Add(24 * time.Hour)); delta < -2*time.Second || delta > 2*time.Second {
+			t.Fatalf("calculateNextBackupTime(%q) = %q, no longer now+24h (want ~%s) — the expression appears to be parsed now; assert the real next run instead", expr, got, want)
+		}
+	}
+}

--- a/pkg/api/router_test.go
+++ b/pkg/api/router_test.go
@@ -1,0 +1,183 @@
+package api
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+)
+
+// routeTable walks the router and returns "METHOD /path" for every registered
+// endpoint.
+func routeTable(t *testing.T) []string {
+	t.Helper()
+
+	r, ok := NewRouter().(chi.Routes)
+	if !ok {
+		t.Fatal("NewRouter did not return a chi.Routes")
+	}
+
+	var routes []string
+	err := chi.Walk(r, func(method, route string, _ http.Handler, _ ...func(http.Handler) http.Handler) error {
+		routes = append(routes, method+" "+route)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk routes: %v", err)
+	}
+	sort.Strings(routes)
+	return routes
+}
+
+func TestRouterRegistersEveryEndpoint(t *testing.T) {
+	want := []string{
+		"DELETE /backup/{id}",
+		"DELETE /sync/{id}",
+		"DELETE /users",
+		"GET /backup",
+		"GET /backup/status/{taskId}",
+		"GET /changestreams/status",
+		"GET /currentUser",
+		"GET /getAdminToken",
+		"GET /oauth/{provider}/config",
+		"GET /sync",
+		"GET /sync/{id}/logs",
+		"GET /sync/{id}/metrics",
+		"GET /sync/{id}/monitor",
+		"GET /sync/{id}/tables",
+		"GET /users",
+		"POST /backup",
+		"POST /backup/execute/{id}",
+		"POST /backup/{id}/run",
+		"POST /login",
+		"POST /login/google/callback",
+		"POST /logout",
+		"POST /sql/execute",
+		"POST /sync",
+		"POST /tables/schema",
+		"POST /test-connection",
+		"PUT /backup/{id}",
+		"PUT /backup/{id}/pause",
+		"PUT /backup/{id}/resume",
+		"PUT /oauth/{provider}/config",
+		"PUT /sync/{id}",
+		"PUT /sync/{id}/start",
+		"PUT /sync/{id}/stop",
+		"PUT /updateAdminPassword",
+		"PUT /updatePassword",
+		"PUT /users/access",
+	}
+
+	got := routeTable(t)
+
+	if len(got) != len(want) {
+		t.Errorf("router exposes %d routes, want %d", len(got), len(want))
+	}
+	inGot := map[string]bool{}
+	for _, r := range got {
+		inGot[r] = true
+	}
+	for _, r := range want {
+		if !inGot[r] {
+			t.Errorf("route %q is not registered", r)
+		}
+	}
+	inWant := map[string]bool{}
+	for _, r := range want {
+		inWant[r] = true
+	}
+	for _, r := range got {
+		if !inWant[r] {
+			t.Errorf("route %q is registered but not expected — update this table deliberately", r)
+		}
+	}
+}
+
+func TestRouterHasNoDuplicateRoutes(t *testing.T) {
+	seen := map[string]bool{}
+	for _, r := range routeTable(t) {
+		if seen[r] {
+			t.Errorf("route %q is registered twice", r)
+		}
+		seen[r] = true
+	}
+}
+
+func TestRouterReturns404ForUnknownPaths(t *testing.T) {
+	for _, path := range []string{"/", "/nope", "/api/sync", "/sync/1/unknown"} {
+		rec := httptest.NewRecorder()
+		NewRouter().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, path, nil))
+
+		if rec.Code != http.StatusNotFound {
+			t.Errorf("GET %s: status = %d, want 404", path, rec.Code)
+		}
+	}
+}
+
+func TestRouterReturns405ForTheWrongMethod(t *testing.T) {
+	cases := []struct{ method, path string }{
+		{http.MethodGet, "/login"},
+		{http.MethodPost, "/users"},
+		{http.MethodDelete, "/sync"},
+		{http.MethodPut, "/backup"},
+	}
+	for _, tc := range cases {
+		rec := httptest.NewRecorder()
+		NewRouter().ServeHTTP(rec, httptest.NewRequest(tc.method, tc.path, nil))
+
+		if rec.Code != http.StatusMethodNotAllowed {
+			t.Errorf("%s %s: status = %d, want 405", tc.method, tc.path, rec.Code)
+		}
+	}
+}
+
+// NewRouter registers no middleware at all: there is no authentication,
+// authorisation, rate limiting, request logging, panic recovery or body-size
+// limit in front of any handler. Every check is left to each handler to
+// perform for itself, so a handler that forgets one is reachable
+// unauthenticated, and a panic in any handler kills the connection rather than
+// returning a 500.
+func TestTheRouterInstallsNoMiddleware(t *testing.T) {
+	r, ok := NewRouter().(chi.Routes)
+	if !ok {
+		t.Fatal("NewRouter did not return a chi.Routes")
+	}
+
+	if n := len(r.Middlewares()); n != 0 {
+		t.Fatalf("the router now installs %d middleware(s) — assert what they enforce instead", n)
+	}
+
+	var withMiddleware []string
+	err := chi.Walk(r, func(method, route string, _ http.Handler, mw ...func(http.Handler) http.Handler) error {
+		if len(mw) > 0 {
+			withMiddleware = append(withMiddleware, fmt.Sprintf("%s %s (%d)", method, route, len(mw)))
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk routes: %v", err)
+	}
+	if len(withMiddleware) > 0 {
+		t.Fatalf("routes now carry middleware: %s — assert what it enforces instead", strings.Join(withMiddleware, ", "))
+	}
+}
+
+// Without chi's Recoverer, a panic in any handler propagates into
+// net/http, which aborts the connection. The client sees a dropped request
+// rather than a 500, and no other request on that connection completes.
+func TestAPanickingHandlerIsNotRecovered(t *testing.T) {
+	r := chi.NewRouter()
+	r.Get("/boom", func(http.ResponseWriter, *http.Request) { panic("handler bug") })
+
+	defer func() {
+		if recover() == nil {
+			t.Fatal("the panic was recovered — a Recoverer appears to be installed; assert the 500 response instead")
+		}
+	}()
+
+	r.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/boom", nil))
+}

--- a/pkg/api/schema_handler_test.go
+++ b/pkg/api/schema_handler_test.go
@@ -1,0 +1,322 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"sort"
+	"testing"
+	"time"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+func TestGetMongoFieldType(t *testing.T) {
+	tests := []struct {
+		name  string
+		value interface{}
+		want  string
+	}{
+		{"int", int(1), "int"},
+		{"int32", int32(1), "int"},
+		{"int64", int64(1), "int"},
+		{"float32", float32(1.5), "float"},
+		{"float64", float64(1.5), "float"},
+		{"string", "x", "string"},
+		{"bool", true, "bool"},
+		{"time", time.Now(), "date"},
+		{"bson.M", bson.M{"a": 1}, "object"},
+		{"map", map[string]interface{}{"a": 1}, "object"},
+		{"slice", []interface{}{1, 2}, "array"},
+		{"nil", nil, "null"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := getMongoFieldType(tc.value); got != tc.want {
+				t.Errorf("getMongoFieldType(%#v) = %q, want %q", tc.value, got, tc.want)
+			}
+		})
+	}
+}
+
+// Anything outside the switch falls through to a Go type name, so the schema a
+// client receives leaks driver-internal types instead of a database type.
+func TestUnknownMongoTypesLeakGoTypeNames(t *testing.T) {
+	tests := []struct {
+		value interface{}
+		want  string
+	}{
+		{primitive.NewObjectID(), "primitive.ObjectID"},
+		{primitive.NewDateTimeFromTime(time.Now()), "primitive.DateTime"},
+		{primitive.Decimal128{}, "primitive.Decimal128"},
+		{bson.A{1, 2}, "primitive.A"},
+		{bson.D{{Key: "a", Value: 1}}, "primitive.D"},
+		{uint8(1), "uint8"},
+		{[]byte("x"), "[]uint8"},
+	}
+
+	for _, tc := range tests {
+		got := getMongoFieldType(tc.value)
+		if got != tc.want {
+			t.Fatalf("getMongoFieldType(%T) = %q, want %q — the switch appears to have been extended; assert the new database type instead", tc.value, got, tc.want)
+		}
+	}
+}
+
+// _id is the field a MongoDB schema always has, and it is reported as an
+// opaque Go type name rather than something a client can map to a column type.
+func TestObjectIDIsNotReportedAsAKnownType(t *testing.T) {
+	if got := getMongoFieldType(primitive.NewObjectID()); got != "primitive.ObjectID" {
+		t.Fatalf("getMongoFieldType(ObjectID) = %q — ObjectID appears to be handled now; assert the intended type instead", got)
+	}
+}
+
+func TestExtractNestedFieldsFlattensWithDottedPaths(t *testing.T) {
+	fields := map[string]string{}
+	extractNestedFields(map[string]interface{}{
+		"name": "alice",
+		"address": map[string]interface{}{
+			"city": "Tokyo",
+			"geo": map[string]interface{}{
+				"lat": 35.6,
+			},
+		},
+	}, "", fields)
+
+	want := map[string]string{
+		"name":            "string",
+		"address":         "object",
+		"address.city":    "string",
+		"address.geo":     "object",
+		"address.geo.lat": "float",
+	}
+	if !reflect.DeepEqual(fields, want) {
+		t.Errorf("fields = %#v, want %#v", fields, want)
+	}
+}
+
+func TestExtractNestedFieldsHonoursThePrefix(t *testing.T) {
+	fields := map[string]string{}
+	extractNestedFields(map[string]interface{}{"id": 1}, "meta", fields)
+
+	if _, ok := fields["meta.id"]; !ok {
+		t.Errorf("fields = %#v, want a meta.id entry", fields)
+	}
+}
+
+func TestExtractNestedFieldsWalksBSONTypes(t *testing.T) {
+	fields := map[string]string{}
+	extractNestedFields(map[string]interface{}{
+		"m": bson.M{"inner": "v"},
+		"d": bson.D{{Key: "inner", Value: int32(1)}},
+	}, "", fields)
+
+	if fields["m.inner"] != "string" {
+		t.Errorf("m.inner = %q, want string (fields = %#v)", fields["m.inner"], fields)
+	}
+	if fields["d.inner"] != "int" {
+		t.Errorf("d.inner = %q, want int (fields = %#v)", fields["d.inner"], fields)
+	}
+}
+
+// A bson.D is walked into, but the entry recorded for the container itself is
+// typed by the switch, which does not list bson.D — so the parent reads as a
+// Go type name while its children read as database types.
+func TestNestedBSONDContainerIsTypedAsAGoValue(t *testing.T) {
+	fields := map[string]string{}
+	extractNestedFields(map[string]interface{}{
+		"d": bson.D{{Key: "inner", Value: "v"}},
+	}, "", fields)
+
+	if fields["d"] != "primitive.D" {
+		t.Fatalf("d = %q, want primitive.D — bson.D appears to be typed as an object now", fields["d"])
+	}
+}
+
+func TestExtractNestedFieldsDoesNotDescendIntoArrays(t *testing.T) {
+	fields := map[string]string{}
+	extractNestedFields(map[string]interface{}{
+		"items": []interface{}{map[string]interface{}{"sku": "A1"}},
+	}, "", fields)
+
+	if fields["items"] != "array" {
+		t.Errorf("items = %q, want array", fields["items"])
+	}
+	if _, ok := fields["items.sku"]; ok {
+		t.Errorf("fields = %#v — array elements are now descended into; assert the new paths instead", fields)
+	}
+}
+
+func TestSortFieldsByNamePutsThePrimaryFirst(t *testing.T) {
+	schema := SchemaResponse{Fields: []Field{
+		{Name: "zeta"},
+		{Name: "alpha"},
+		{Name: "_id", IsPrimary: true},
+		{Name: "mid"},
+	}}
+
+	sortFieldsByName(&schema)
+
+	got := make([]string, len(schema.Fields))
+	for i, f := range schema.Fields {
+		got[i] = f.Name
+	}
+	want := []string{"_id", "alpha", "mid", "zeta"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("order = %v, want %v", got, want)
+	}
+}
+
+func TestSortFieldsByNameHandlesEmptyAndSingle(t *testing.T) {
+	empty := SchemaResponse{}
+	sortFieldsByName(&empty)
+	if len(empty.Fields) != 0 {
+		t.Errorf("empty schema gained fields: %#v", empty.Fields)
+	}
+
+	one := SchemaResponse{Fields: []Field{{Name: "only"}}}
+	sortFieldsByName(&one)
+	if one.Fields[0].Name != "only" {
+		t.Errorf("single field became %q", one.Fields[0].Name)
+	}
+}
+
+// The comparator reports less(i,j) and less(j,i) both true whenever two fields
+// are primary, which is not a strict weak ordering and puts sort.Slice outside
+// its contract. A composite primary key — routine in MySQL — therefore has no
+// defined order, and the fields are not sorted by name either.
+func TestCompositePrimaryKeysHaveNoDefinedOrder(t *testing.T) {
+	less := func(a, b Field) bool {
+		if a.IsPrimary {
+			return true
+		}
+		if b.IsPrimary {
+			return false
+		}
+		return a.Name < b.Name
+	}
+	pk1 := Field{Name: "tenant_id", IsPrimary: true}
+	pk2 := Field{Name: "order_id", IsPrimary: true}
+
+	if !less(pk1, pk2) || !less(pk2, pk1) {
+		t.Fatal("the comparator is now a strict weak ordering — sortFieldsByName appears to be fixed; assert the sorted order instead")
+	}
+
+	// Confirm the consequence: primary fields do not come out sorted by name.
+	schema := SchemaResponse{Fields: []Field{
+		{Name: "zz_pk", IsPrimary: true},
+		{Name: "aa_pk", IsPrimary: true},
+		{Name: "mm_pk", IsPrimary: true},
+	}}
+	sortFieldsByName(&schema)
+
+	names := make([]string, len(schema.Fields))
+	for i, f := range schema.Fields {
+		names[i] = f.Name
+	}
+	if sort.StringsAreSorted(names) {
+		t.Fatalf("primary fields came out sorted (%v) — sortFieldsByName appears to be fixed; assert the sorted order instead", names)
+	}
+}
+
+func TestGetTableSchemaHandlerRejectsMalformedJSON(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/tables/schema", bytes.NewBufferString("{not json"))
+	rec := httptest.NewRecorder()
+
+	GetTableSchemaHandler(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", rec.Code)
+	}
+}
+
+func TestGetTableSchemaHandlerRejectsAnEmptyBody(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/tables/schema", bytes.NewBuffer(nil))
+	rec := httptest.NewRecorder()
+
+	GetTableSchemaHandler(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", rec.Code)
+	}
+}
+
+func TestGetTableSchemaHandlerRejectsUnsupportedSourceTypes(t *testing.T) {
+	for _, sourceType := range []string{"", "redis", "oracle", "MongoDB", "MySQL"} {
+		body, _ := json.Marshal(SchemaRequest{SourceType: sourceType, TableName: "t"})
+		req := httptest.NewRequest(http.MethodPost, "/tables/schema", bytes.NewReader(body))
+		rec := httptest.NewRecorder()
+
+		GetTableSchemaHandler(rec, req)
+
+		if rec.Code != http.StatusBadRequest {
+			t.Errorf("sourceType %q: status = %d, want 400", sourceType, rec.Code)
+			continue
+		}
+		if got := rec.Header().Get("Content-Type"); got != "application/json" {
+			t.Errorf("sourceType %q: Content-Type = %q, want application/json", sourceType, got)
+		}
+		var resp map[string]interface{}
+		if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+			t.Errorf("sourceType %q: body is not JSON: %v", sourceType, err)
+			continue
+		}
+		if resp["success"] != false {
+			t.Errorf("sourceType %q: success = %v, want false", sourceType, resp["success"])
+		}
+	}
+}
+
+// The source type is matched case-sensitively while the rest of the codebase
+// stores it lower-cased; a caller that sends the display-cased name gets
+// "Unsupported database type" rather than a schema.
+func TestSourceTypeMatchingIsCaseSensitive(t *testing.T) {
+	body, _ := json.Marshal(SchemaRequest{SourceType: "MongoDB", TableName: "t"})
+	req := httptest.NewRequest(http.MethodPost, "/tables/schema", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+
+	GetTableSchemaHandler(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d — the source type appears to be normalised now; assert the schema response instead", rec.Code)
+	}
+}
+
+func TestSchemaFailuresReportAJSONError(t *testing.T) {
+	body, _ := json.Marshal(map[string]interface{}{
+		"sourceType": "mysql",
+		"connection": map[string]string{
+			"host": "127.0.0.1", "port": "1", "user": "svc",
+			"password": "hunter2", "database": "app",
+		},
+		"tableName": "t",
+	})
+	req := httptest.NewRequest(http.MethodPost, "/tables/schema", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+
+	GetTableSchemaHandler(rec, req)
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500", rec.Code)
+	}
+	var resp map[string]interface{}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("body is not JSON: %v (%q)", err, rec.Body.String())
+	}
+	if resp["success"] != false {
+		t.Errorf("success = %v, want false", resp["success"])
+	}
+	msg, _ := resp["message"].(string)
+	if msg == "" {
+		t.Errorf("message is empty (body: %s)", rec.Body.String())
+	}
+	// The DSN is assembled inside the driver, so the supplied password does not
+	// reach the client. Guard that, since the message is otherwise verbatim.
+	if bytes.Contains(rec.Body.Bytes(), []byte("hunter2")) {
+		t.Errorf("the supplied password leaked into the response: %s", rec.Body.String())
+	}
+}

--- a/pkg/api/task_handler_test.go
+++ b/pkg/api/task_handler_test.go
@@ -1,0 +1,350 @@
+package api
+
+import (
+	"database/sql"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+// isolateCrontab empties PATH so the `crontab` command cannot be found. The
+// backup handlers call CronManager.SyncCrontab unconditionally, which shells
+// out to crontab and would otherwise rewrite the crontab of whoever runs the
+// suite. With crontab unreachable the handlers log a warning and carry on,
+// which is the behaviour under test.
+func isolateCrontab(t *testing.T) {
+	t.Helper()
+	t.Setenv("PATH", t.TempDir())
+}
+
+// useTempTaskDB points the package at a throwaway SQLite file carrying the
+// sync_tasks and backup_tasks schema, so the list and mutate handlers can be
+// exercised without touching the database tracked in this repository.
+func useTempTaskDB(t *testing.T) *sql.DB {
+	t.Helper()
+
+	isolateCrontab(t)
+
+	path := filepath.Join(t.TempDir(), "sync.db")
+	t.Setenv("SYNC_DB_PATH", path)
+
+	db, err := sql.Open("sqlite3", path)
+	if err != nil {
+		t.Fatalf("open temp sqlite: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	const schema = `
+CREATE TABLE sync_tasks (
+    id               INTEGER PRIMARY KEY AUTOINCREMENT,
+    enable           INTEGER NOT NULL DEFAULT 1,
+    last_update_time DATETIME,
+    last_run_time    DATETIME,
+    config_json      TEXT NOT NULL
+);
+CREATE TABLE backup_tasks (
+    id               INTEGER PRIMARY KEY AUTOINCREMENT,
+    enable           INTEGER NOT NULL DEFAULT 1,
+    last_update_time DATETIME,
+    last_backup_time DATETIME,
+    next_backup_time DATETIME,
+    config_json      TEXT NOT NULL
+);`
+	if _, err := db.Exec(schema); err != nil {
+		t.Fatalf("create schema: %v", err)
+	}
+	return db
+}
+
+func insertSyncTask(t *testing.T, db *sql.DB, enable int, cfg string) {
+	t.Helper()
+
+	if _, err := db.Exec(
+		`INSERT INTO sync_tasks (enable, last_update_time, last_run_time, config_json)
+		 VALUES (?, '2026-08-21 00:30:00', '2026-08-21 01:00:00', ?)`, enable, cfg); err != nil {
+		t.Fatalf("insert sync task: %v", err)
+	}
+}
+
+func decodeEnvelope(t *testing.T, rec *httptest.ResponseRecorder) map[string]interface{} {
+	t.Helper()
+
+	var resp map[string]interface{}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("body is not JSON: %v (%q)", err, rec.Body.String())
+	}
+	return resp
+}
+
+func TestSyncListHandlerReturnsTheTaskTable(t *testing.T) {
+	db := useTempTaskDB(t)
+	insertSyncTask(t, db, 1, `{"type":"mysql","taskName":"tokyo to osaka","securityEnabled":true}`)
+	insertSyncTask(t, db, 0, `{"type":"mongodb"}`)
+
+	rec := httptest.NewRecorder()
+	SyncListHandler(rec, httptest.NewRequest(http.MethodGet, "/sync", nil))
+
+	resp := decodeEnvelope(t, rec)
+	if resp["success"] != true {
+		t.Fatalf("success = %v (body: %s)", resp["success"], rec.Body.String())
+	}
+	data, ok := resp["data"].([]interface{})
+	if !ok || len(data) != 2 {
+		t.Fatalf("data = %#v, want 2 tasks", resp["data"])
+	}
+
+	first := data[0].(map[string]interface{})
+	if first["taskName"] != "tokyo to osaka" {
+		t.Errorf("taskName = %v", first["taskName"])
+	}
+	if first["status"] != "Running" || first["enable"] != true {
+		t.Errorf("status = %v, enable = %v, want Running/true", first["status"], first["enable"])
+	}
+	if first["securityEnabled"] != true {
+		t.Errorf("securityEnabled = %v, want true", first["securityEnabled"])
+	}
+	if first["lastUpdateTime"] != "2026-08-21 09:30:00" {
+		t.Errorf("lastUpdateTime = %v, want the JST-shifted value", first["lastUpdateTime"])
+	}
+
+	second := data[1].(map[string]interface{})
+	if second["status"] != "Stopped" || second["enable"] != false {
+		t.Errorf("status = %v, enable = %v, want Stopped/false", second["status"], second["enable"])
+	}
+	if second["taskName"] != "Sync Task 2" {
+		t.Errorf("taskName = %v, want the generated default", second["taskName"])
+	}
+}
+
+func TestSyncListHandlerOnAnEmptyTable(t *testing.T) {
+	useTempTaskDB(t)
+
+	rec := httptest.NewRecorder()
+	SyncListHandler(rec, httptest.NewRequest(http.MethodGet, "/sync", nil))
+
+	resp := decodeEnvelope(t, rec)
+	if resp["success"] != true {
+		t.Fatalf("success = %v", resp["success"])
+	}
+	// A nil slice marshals to null, not [], so an empty list and a failure are
+	// distinguishable only by the success flag.
+	if resp["data"] != nil {
+		t.Fatalf("data = %#v — an empty list now marshals as a JSON array; assert that instead", resp["data"])
+	}
+}
+
+// A row whose config_json cannot be parsed is logged at warn level and then
+// returned as a task with every field blank, so a corrupt configuration
+// surfaces as an apparently valid but empty entry rather than an error.
+func TestAnUnparseableTaskConfigIsReturnedAsBlank(t *testing.T) {
+	db := useTempTaskDB(t)
+	insertSyncTask(t, db, 1, `{not json`)
+
+	rec := httptest.NewRecorder()
+	SyncListHandler(rec, httptest.NewRequest(http.MethodGet, "/sync", nil))
+
+	resp := decodeEnvelope(t, rec)
+	if resp["success"] != true {
+		t.Fatalf("success = %v — a corrupt config appears to be reported now; assert the error instead", resp["success"])
+	}
+	data := resp["data"].([]interface{})
+	if len(data) != 1 {
+		t.Fatalf("data = %#v, want the corrupt row", resp["data"])
+	}
+	row := data[0].(map[string]interface{})
+	if row["sourceType"] != "" || row["sourceConn"] != nil {
+		t.Fatalf("row = %#v — the corrupt row is no longer returned blank", row)
+	}
+}
+
+// The stored connection blocks are echoed verbatim, so the source and target
+// passwords are served to any caller that can reach GET /api/sync. The handler
+// performs no authentication of its own and the router installs none, so that
+// is any caller who can reach the port.
+func TestSyncListHandlerServesConnectionPasswords(t *testing.T) {
+	db := useTempTaskDB(t)
+	insertSyncTask(t, db, 1, `{
+		"type":"mysql",
+		"sourceConn":{"host":"tokyo","port":"3306","user":"repl","password":"tokyo-secret","database":"app"},
+		"targetConn":{"host":"osaka","port":"3306","user":"repl","password":"osaka-secret","database":"app"}
+	}`)
+
+	rec := httptest.NewRecorder()
+	SyncListHandler(rec, httptest.NewRequest(http.MethodGet, "/sync", nil))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d — the handler appears to require credentials now", rec.Code)
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, "tokyo-secret") || !strings.Contains(body, "osaka-secret") {
+		t.Fatalf("the connection passwords are no longer served — they appear to be redacted; assert the redaction instead (body: %s)", body)
+	}
+}
+
+func TestSyncListHandlerReportsAMissingTable(t *testing.T) {
+	t.Setenv("SYNC_DB_PATH", filepath.Join(t.TempDir(), "empty.db"))
+
+	rec := httptest.NewRecorder()
+	SyncListHandler(rec, httptest.NewRequest(http.MethodGet, "/sync", nil))
+
+	resp := decodeEnvelope(t, rec)
+	if resp["success"] != false {
+		t.Errorf("success = %v, want false", resp["success"])
+	}
+	if resp["error"] != "query sync_tasks fail" {
+		t.Errorf("error = %v", resp["error"])
+	}
+}
+
+func TestSyncDeleteHandlerRejectsANonNumericID(t *testing.T) {
+	useTempTaskDB(t)
+
+	for _, id := range []string{"abc", "", "1;DROP TABLE sync_tasks", "1.5"} {
+		rec := httptest.NewRecorder()
+		serveWithURLParams(rec, httptest.NewRequest(http.MethodDelete, "/sync/{id}", nil),
+			SyncDeleteHandler, map[string]string{"id": id})
+
+		resp := decodeEnvelope(t, rec)
+		if resp["success"] == true {
+			t.Errorf("id %q: success = true, want a rejection (body: %s)", id, rec.Body.String())
+		}
+	}
+}
+
+func TestSyncStartAndStopFlipTheEnableColumn(t *testing.T) {
+	db := useTempTaskDB(t)
+	insertSyncTask(t, db, 0, `{"type":"mysql","taskName":"t"}`)
+
+	enable := func() int {
+		t.Helper()
+		var n int
+		if err := db.QueryRow("SELECT enable FROM sync_tasks WHERE id=1").Scan(&n); err != nil {
+			t.Fatalf("read enable: %v", err)
+		}
+		return n
+	}
+
+	rec := httptest.NewRecorder()
+	serveWithURLParams(rec, httptest.NewRequest(http.MethodPut, "/sync/1/start", nil),
+		SyncStartHandler, map[string]string{"id": "1"})
+	if resp := decodeEnvelope(t, rec); resp["success"] != true {
+		t.Fatalf("start: %s", rec.Body.String())
+	}
+	if got := enable(); got != 1 {
+		t.Errorf("after start enable = %d, want 1", got)
+	}
+
+	rec = httptest.NewRecorder()
+	serveWithURLParams(rec, httptest.NewRequest(http.MethodPut, "/sync/1/stop", nil),
+		SyncStopHandler, map[string]string{"id": "1"})
+	if resp := decodeEnvelope(t, rec); resp["success"] != true {
+		t.Fatalf("stop: %s", rec.Body.String())
+	}
+	if got := enable(); got != 0 {
+		t.Errorf("after stop enable = %d, want 0", got)
+	}
+}
+
+func TestStartingAMissingTaskIsRejected(t *testing.T) {
+	useTempTaskDB(t)
+
+	rec := httptest.NewRecorder()
+	serveWithURLParams(rec, httptest.NewRequest(http.MethodPut, "/sync/999/start", nil),
+		SyncStartHandler, map[string]string{"id": "999"})
+
+	resp := decodeEnvelope(t, rec)
+	if resp["success"] != false {
+		t.Errorf("success = %v, want false for a task that does not exist", resp["success"])
+	}
+}
+
+func TestBackupListHandlerReturnsTheTaskTable(t *testing.T) {
+	db := useTempTaskDB(t)
+	if _, err := db.Exec(
+		`INSERT INTO backup_tasks (enable, last_update_time, last_backup_time, next_backup_time, config_json)
+		 VALUES (1, '2026-08-21 00:00:00', '2026-08-20 18:00:00', '2026-08-22 18:00:00', ?)`,
+		`{"name":"nightly","sourceType":"mysql"}`); err != nil {
+		t.Fatalf("insert backup task: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	BackupListHandler(rec, httptest.NewRequest(http.MethodGet, "/backup", nil))
+
+	resp := decodeEnvelope(t, rec)
+	if resp["success"] != true {
+		t.Fatalf("success = %v (body: %s)", resp["success"], rec.Body.String())
+	}
+	data, ok := resp["data"].([]interface{})
+	if !ok || len(data) != 1 {
+		t.Fatalf("data = %#v, want 1 task", resp["data"])
+	}
+	if got := data[0].(map[string]interface{})["status"]; got != "enabled" {
+		t.Errorf("status = %v, want enabled", got)
+	}
+}
+
+func TestBackupListHandlerReportsAMissingTable(t *testing.T) {
+	t.Setenv("SYNC_DB_PATH", filepath.Join(t.TempDir(), "empty.db"))
+
+	rec := httptest.NewRecorder()
+	BackupListHandler(rec, httptest.NewRequest(http.MethodGet, "/backup", nil))
+
+	resp := decodeEnvelope(t, rec)
+	if resp["success"] != false {
+		t.Errorf("success = %v, want false", resp["success"])
+	}
+}
+
+func TestBackupDeleteHandlerRejectsANonNumericID(t *testing.T) {
+	useTempTaskDB(t)
+
+	for _, id := range []string{"abc", "", "1.5"} {
+		rec := httptest.NewRecorder()
+		serveWithURLParams(rec, httptest.NewRequest(http.MethodDelete, "/backup/{id}", nil),
+			BackupDeleteHandler, map[string]string{"id": id})
+
+		if rec.Code == http.StatusOK {
+			resp := decodeEnvelope(t, rec)
+			if resp["success"] == true {
+				t.Errorf("id %q: success = true, want a rejection", id)
+			}
+		}
+	}
+}
+
+func TestBackupPauseAndResumeFlipTheEnableColumn(t *testing.T) {
+	db := useTempTaskDB(t)
+	if _, err := db.Exec(
+		`INSERT INTO backup_tasks (enable, config_json) VALUES (1, ?)`,
+		`{"name":"nightly","cronExpression":"0 3 * * *"}`); err != nil {
+		t.Fatalf("insert backup task: %v", err)
+	}
+
+	enable := func() int {
+		t.Helper()
+		var n int
+		if err := db.QueryRow("SELECT enable FROM backup_tasks WHERE id=1").Scan(&n); err != nil {
+			t.Fatalf("read enable: %v", err)
+		}
+		return n
+	}
+
+	rec := httptest.NewRecorder()
+	serveWithURLParams(rec, httptest.NewRequest(http.MethodPut, "/backup/1/pause", nil),
+		BackupPauseHandler, map[string]string{"id": "1"})
+	if got := enable(); got != 0 {
+		t.Errorf("after pause enable = %d, want 0 (body: %s)", got, rec.Body.String())
+	}
+
+	rec = httptest.NewRecorder()
+	serveWithURLParams(rec, httptest.NewRequest(http.MethodPut, "/backup/1/resume", nil),
+		BackupResumeHandler, map[string]string{"id": "1"})
+	if got := enable(); got != 1 {
+		t.Errorf("after resume enable = %d, want 1 (body: %s)", got, rec.Body.String())
+	}
+}

--- a/pkg/backup/executor_test.go
+++ b/pkg/backup/executor_test.go
@@ -1,0 +1,453 @@
+package backup
+
+import (
+	"reflect"
+	"regexp"
+	"testing"
+	"time"
+)
+
+// newExecutor returns an executor usable for the pure helpers, which never touch the
+// database handle.
+func newExecutor() *BackupExecutor { return &BackupExecutor{} }
+
+func TestExtractTablePrefix(t *testing.T) {
+	tests := []struct {
+		name  string
+		table string
+		want  string
+	}{
+		{"monthly with underscore", "orders_202608", "orders"},
+		{"daily with underscore", "orders_20260821", "orders"},
+		{"yearly with underscore", "orders_2026", "orders"},
+		{"monthly without underscore", "orders202608", "orders"},
+		{"numeric suffix", "users1", "users"},
+		{"no suffix", "users", "users"},
+		{"underscore before number keeps it", "table_1", "table_"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := newExecutor().extractTablePrefix(tt.table); got != tt.want {
+				t.Errorf("extractTablePrefix(%q) = %q, want %q", tt.table, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestExtractTablePrefixPatternOrderLeavesStrayDigits records a defect in the
+// pattern list: `\d{6}$` is tried before `\d{8}$`, so an eight-digit date with
+// no underscore separator has only its last six digits stripped, leaving two
+// stray digits on the prefix.
+func TestExtractTablePrefixPatternOrderLeavesStrayDigits(t *testing.T) {
+	tests := []struct{ table, want string }{
+		{"orders20260821", "orders20"}, // want "orders"
+		{"20260821", "20"},             // an all-numeric name loses all but two digits
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.table, func(t *testing.T) {
+			got := newExecutor().extractTablePrefix(tt.table)
+
+			if got == "orders" || got == "" {
+				t.Fatalf("extractTablePrefix(%q) = %q; the pattern order may have been "+
+					"fixed, so assert the correct prefix instead", tt.table, got)
+			}
+			if got != tt.want {
+				t.Errorf("extractTablePrefix(%q) = %q, want %q", tt.table, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGroupTablesByPrefix(t *testing.T) {
+	got := newExecutor().groupTablesByPrefix([]string{
+		"orders_202606", "orders_202607", "orders_202608",
+		"users", "users1", "users2",
+		"events_20260821",
+	})
+
+	want := map[string][]string{
+		"orders": {"orders_202606", "orders_202607", "orders_202608"},
+		"users":  {"users", "users1", "users2"},
+		"events": {"events_20260821"},
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("groupTablesByPrefix =\n  %v\nwant\n  %v", got, want)
+	}
+}
+
+func TestGroupTablesByPrefixEmpty(t *testing.T) {
+	if got := newExecutor().groupTablesByPrefix(nil); len(got) != 0 {
+		t.Errorf("groupTablesByPrefix(nil) = %v, want an empty map", got)
+	}
+}
+
+func TestParseYearMonth(t *testing.T) {
+	year, month, err := parseYearMonth("202608")
+	if err != nil {
+		t.Fatalf("parseYearMonth returned %v", err)
+	}
+	if year != 2026 || month != time.August {
+		t.Errorf("parseYearMonth(\"202608\") = %d/%v, want 2026/August", year, month)
+	}
+
+	for _, bad := range []string{"", "2026", "2026081", "20260a", "abcdef", "202600", "202613"} {
+		if _, _, err := parseYearMonth(bad); err == nil {
+			t.Errorf("parseYearMonth(%q) succeeded, want an error", bad)
+		}
+	}
+}
+
+func TestParseYear(t *testing.T) {
+	year, err := parseYear("2026")
+	if err != nil {
+		t.Fatalf("parseYear returned %v", err)
+	}
+	if year != 2026 {
+		t.Errorf("parseYear(\"2026\") = %d, want 2026", year)
+	}
+
+	for _, bad := range []string{"", "202", "20266", "20a6"} {
+		if _, err := parseYear(bad); err == nil {
+			t.Errorf("parseYear(%q) succeeded, want an error", bad)
+		}
+	}
+}
+
+func TestExtractTableTimePattern(t *testing.T) {
+	tests := []struct {
+		name  string
+		table string
+		start time.Time
+		end   time.Time
+	}{
+		{
+			"monthly", "orders_202608",
+			time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC),
+			time.Date(2026, 9, 1, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			"daily", "orders_20260821",
+			time.Date(2026, 8, 21, 0, 0, 0, 0, time.UTC),
+			time.Date(2026, 8, 22, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			"yearly", "orders_2026",
+			time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+			time.Date(2027, 1, 1, 0, 0, 0, 0, time.UTC),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := newExecutor().extractTableTimePattern(tt.table)
+			if got == nil {
+				t.Fatalf("extractTableTimePattern(%q) = nil", tt.table)
+			}
+			if !got.Start.Equal(tt.start) || !got.End.Equal(tt.end) {
+				t.Errorf("extractTableTimePattern(%q) = %v..%v, want %v..%v",
+					tt.table, got.Start, got.End, tt.start, tt.end)
+			}
+		})
+	}
+
+	// Names carrying no date pattern yield nil, which callers treat as
+	// "include the table to be safe".
+	for _, table := range []string{"users", "orders_bak", "orders_2026081"} {
+		if got := newExecutor().extractTableTimePattern(table); got != nil {
+			t.Errorf("extractTableTimePattern(%q) = %v, want nil", table, got)
+		}
+	}
+}
+
+func TestIsTableRelevantForTimeRange(t *testing.T) {
+	august := &TimeRange{
+		Start: time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC),
+		End:   time.Date(2026, 9, 1, 0, 0, 0, 0, time.UTC),
+	}
+
+	tests := []struct {
+		table string
+		want  bool
+	}{
+		{"orders_202608", true},   // exactly the range
+		{"orders_20260815", true}, // a day inside it
+		{"orders_2026", true},     // the year overlaps
+		{"orders_202606", false},  // two months before: genuinely outside
+		{"orders_202610", false},  // two months after: genuinely outside
+		{"users", true},           // no pattern, included to be safe
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.table, func(t *testing.T) {
+			if got := newExecutor().isTableRelevantForTimeRange(tt.table, august); got != tt.want {
+				t.Errorf("isTableRelevantForTimeRange(%q) = %v, want %v", tt.table, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestIsTableRelevantForTimeRangeIncludesTouchingIntervals records an
+// off-by-one. Both TimeRange values are half-open — extractTableTimePattern
+// builds End with AddDate, so a monthly table ends on the first of the next
+// month — but the overlap test uses Before and After rather than their strict
+// complements. An interval whose End equals the range Start therefore counts as
+// overlapping, so the months either side of the window are always pulled in: a
+// one-month backup exports three months of tables.
+func TestIsTableRelevantForTimeRangeIncludesTouchingIntervals(t *testing.T) {
+	august := &TimeRange{
+		Start: time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC),
+		End:   time.Date(2026, 9, 1, 0, 0, 0, 0, time.UTC),
+	}
+
+	for _, table := range []string{
+		"orders_202607",   // ends exactly at the range start
+		"orders_20260731", // ditto, one day granularity
+		"orders_202609",   // starts exactly at the range end
+	} {
+		t.Run(table, func(t *testing.T) {
+			if !newExecutor().isTableRelevantForTimeRange(table, august) {
+				t.Errorf("isTableRelevantForTimeRange(%q) = false; the boundary "+
+					"comparison may have been tightened, so assert that instead", table)
+			}
+		})
+	}
+}
+
+func TestFilterRelevantTables(t *testing.T) {
+	tables := []string{"orders_202607", "orders_202608", "orders_202609"}
+
+	t.Run("no conditions returns everything", func(t *testing.T) {
+		got := newExecutor().filterRelevantTables(tables, nil, "orders")
+		if !reflect.DeepEqual(got, tables) {
+			t.Errorf("got %v, want %v", got, tables)
+		}
+	})
+
+	t.Run("conditions without a time range return everything", func(t *testing.T) {
+		conditions := map[string]map[string]interface{}{
+			"orders": {"status": "active"},
+		}
+		got := newExecutor().filterRelevantTables(tables, conditions, "orders")
+		if !reflect.DeepEqual(got, tables) {
+			t.Errorf("got %v, want %v", got, tables)
+		}
+	})
+}
+
+// TestFilterRelevantTablesFallsBackToFirstTable records a defect: when a time
+// range excludes every table, the function backs up `tables[0]` instead of
+// reporting that nothing matched. The job then succeeds while archiving a table
+// outside the requested window, which looks like a successful backup of the
+// wrong data.
+func TestFilterRelevantTablesFallsBackToFirstTable(t *testing.T) {
+	// A daily range around today cannot overlap tables from 2020.
+	tables := []string{"orders_202001", "orders_202002"}
+	conditions := map[string]map[string]interface{}{
+		"orders": {"created_at": map[string]interface{}{
+			"type":        "daily",
+			"startOffset": float64(-1),
+			"endOffset":   float64(0),
+		}},
+	}
+
+	got := newExecutor().filterRelevantTables(tables, conditions, "orders")
+
+	if len(got) != 1 || got[0] != "orders_202001" {
+		t.Errorf("filterRelevantTables = %v; the fallback may have been replaced "+
+			"with an error or an empty result, so assert that instead", got)
+	}
+}
+
+// TestFilterRelevantTablesPanicsOnEmptyInput records that the same fallback
+// indexes tables[0] without checking the slice, so an empty table list with a
+// time-range condition panics instead of returning nothing.
+func TestFilterRelevantTablesPanicsOnEmptyInput(t *testing.T) {
+	conditions := map[string]map[string]interface{}{
+		"orders": {"created_at": map[string]interface{}{
+			"type":        "daily",
+			"startOffset": float64(-1),
+			"endOffset":   float64(0),
+		}},
+	}
+
+	defer func() {
+		if recover() == nil {
+			t.Error("filterRelevantTables with no tables no longer panics; a guard " +
+				"may have been added, so assert the returned value instead")
+		}
+	}()
+
+	newExecutor().filterRelevantTables(nil, conditions, "orders")
+}
+
+func TestExtractTimeRange(t *testing.T) {
+	t.Run("nil without a daily entry", func(t *testing.T) {
+		for _, query := range []map[string]interface{}{
+			nil,
+			{"status": "active"},
+			{"created_at": map[string]interface{}{"type": "weekly"}},
+			{"created_at": map[string]interface{}{"$gt": 1}},
+		} {
+			if got := newExecutor().extractTimeRange(query); got != nil {
+				t.Errorf("extractTimeRange(%v) = %v, want nil", query, got)
+			}
+		}
+	})
+
+	t.Run("spans one day per offset step", func(t *testing.T) {
+		query := map[string]interface{}{"created_at": map[string]interface{}{
+			"type":        "daily",
+			"startOffset": float64(-3),
+			"endOffset":   float64(0),
+		}}
+
+		got := newExecutor().extractTimeRange(query)
+		if got == nil {
+			t.Fatal("extractTimeRange returned nil")
+		}
+		// The end bound is endOffset+1, so -3..0 covers four days.
+		if want := 4 * 24 * time.Hour; got.End.Sub(got.Start) != want {
+			t.Errorf("range spans %v, want %v", got.End.Sub(got.Start), want)
+		}
+	})
+
+	// The -1..0 default spans two days, not one: the end bound is computed as
+	// endOffset+1, so "yesterday" also takes in today, whose data is still
+	// being written. utils.convertToMongoDBTimeRange, the other implementation
+	// of the same configuration, omits the +1 and spans a single day — the same
+	// task description therefore means different windows depending on which
+	// code path handles it.
+	t.Run("default offsets span two days", func(t *testing.T) {
+		query := map[string]interface{}{"created_at": map[string]interface{}{"type": "daily"}}
+
+		got := newExecutor().extractTimeRange(query)
+		if got == nil {
+			t.Fatal("extractTimeRange returned nil")
+		}
+		if want := 48 * time.Hour; got.End.Sub(got.Start) != want {
+			t.Errorf("range spans %v, want %v for the -1..0 default", got.End.Sub(got.Start), want)
+		}
+	})
+
+	t.Run("offsets must be JSON numbers", func(t *testing.T) {
+		// Strings and Go ints fail the float64 assertion and are silently
+		// replaced by the -1..0 default rather than reported.
+		query := map[string]interface{}{"created_at": map[string]interface{}{
+			"type":        "daily",
+			"startOffset": "-3",
+			"endOffset":   0,
+		}}
+
+		got := newExecutor().extractTimeRange(query)
+		if got == nil {
+			t.Fatal("extractTimeRange returned nil")
+		}
+		if want := 48 * time.Hour; got.End.Sub(got.Start) != want {
+			t.Errorf("range spans %v; non-float offsets are no longer silently "+
+				"replaced by the default, so assert the new behaviour instead",
+				got.End.Sub(got.Start))
+		}
+	})
+}
+
+func TestProcessFileNamePattern(t *testing.T) {
+	yesterday := time.Now().AddDate(0, 0, -1)
+
+	t.Run("empty pattern uses table and yesterday", func(t *testing.T) {
+		want := "orders_" + yesterday.Format("2006-01-02")
+		if got := processFileNamePattern("", "orders"); got != want {
+			t.Errorf("processFileNamePattern = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("table placeholder is substituted", func(t *testing.T) {
+		got := processFileNamePattern("{table}_{YYYY}{MM}{DD}.json", "orders")
+		want := "orders_" + yesterday.Format("20060102") + ".json"
+		if got != want {
+			t.Errorf("processFileNamePattern = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("uppercase table placeholder", func(t *testing.T) {
+		if got := processFileNamePattern("{TABLE}.json", "orders"); got != "ORDERS.json" {
+			t.Errorf("processFileNamePattern = %q, want %q", got, "ORDERS.json")
+		}
+	})
+
+	t.Run("table name is prepended before the extension when absent", func(t *testing.T) {
+		got := processFileNamePattern("dump.json", "orders")
+		if got != "orders_dump.json" {
+			t.Errorf("processFileNamePattern = %q, want %q", got, "orders_dump.json")
+		}
+	})
+
+	t.Run("regex anchors are stripped", func(t *testing.T) {
+		got := processFileNamePattern("^{table}$", "orders")
+		if got != "orders" {
+			t.Errorf("processFileNamePattern = %q, want %q", got, "orders")
+		}
+	})
+}
+
+// TestProcessFileNamePatternInheritsPlaceholderCorruption shows T-017 reaching
+// the backup file name: descriptive wording in the pattern is rewritten with
+// digits before the table name is attached.
+func TestProcessFileNamePatternInheritsPlaceholderCorruption(t *testing.T) {
+	yesterday := time.Now().AddDate(0, 0, -1)
+
+	got := processFileNamePattern("summary_YYYYMM.json", "orders")
+
+	want := "orders_su" + yesterday.Format("01") + "ary_" + yesterday.Format("200601") + ".json"
+	if got != want {
+		t.Errorf("processFileNamePattern = %q, want %q", got, want)
+	}
+}
+
+func TestBuildMongoDBConnectionString(t *testing.T) {
+	tests := []struct {
+		name            string
+		url, user, pass string
+		want            string
+	}{
+		{
+			"with credentials", "localhost:27017", "root", "root",
+			"mongodb://root:root@localhost:27017/?authSource=admin&directConnection=true",
+		},
+		{
+			"without credentials", "localhost:27017", "", "",
+			"mongodb://localhost:27017/?directConnection=true",
+		},
+		{
+			// Same asymmetry as the syncer DSN builder: a user without a
+			// password is dropped and the connection becomes anonymous.
+			"user without password", "localhost:27017", "root", "",
+			"mongodb://localhost:27017/?directConnection=true",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := buildMongoDBConnectionString(tt.url, tt.user, tt.pass); got != tt.want {
+				t.Errorf("buildMongoDBConnectionString =\n  %q\nwant\n  %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestBuildMongoDBConnectionStringForcesDirectConnection mirrors T-007 for the
+// backup path: every connection string pins the driver to a single node, so a
+// backup taken against a replica set stops working after an election.
+func TestBuildMongoDBConnectionStringForcesDirectConnection(t *testing.T) {
+	for _, conn := range []string{
+		buildMongoDBConnectionString("localhost:27017", "root", "root"),
+		buildMongoDBConnectionString("localhost:27017", "", ""),
+	} {
+		if !regexp.MustCompile(`directConnection=true`).MatchString(conn) {
+			t.Errorf("connection string %q no longer forces directConnection; "+
+				"assert the new behaviour instead", conn)
+		}
+	}
+}

--- a/pkg/backup/external_commands_test.go
+++ b/pkg/backup/external_commands_test.go
@@ -1,0 +1,772 @@
+package backup
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// stubBin installs an executable stub on PATH under the given name. The stub
+// appends its arguments to <dir>/<name>.args, runs the supplied shell body, and
+// exits with the given status. Returns the directory so callers can read the
+// recorded arguments.
+func stubBin(t *testing.T, dir, name, body string, exitCode int) {
+	t.Helper()
+
+	// The outer PATH is restricted to the stub directory so exec.CommandContext
+	// cannot reach a real mysqldump, zip or gsutil. The stub therefore needs its
+	// own PATH to find coreutils.
+	script := fmt.Sprintf(`#!/bin/sh
+PATH=/usr/bin:/bin:/usr/local/bin
+printf '%%s\n' "$@" >> %q
+%s
+exit %d
+`, filepath.Join(dir, name+".args"), body, exitCode)
+
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatalf("write stub %s: %v", name, err)
+	}
+}
+
+// stubPATH points PATH at a fresh directory holding only the stubs a test
+// installs, so nothing can reach a real mysqldump, zip or gsutil.
+func stubPATH(t *testing.T) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	t.Setenv("PATH", dir)
+	return dir
+}
+
+// stubArgs returns the arguments a stub recorded, one per line.
+func stubArgs(t *testing.T, dir, name string) []string {
+	t.Helper()
+
+	data, err := os.ReadFile(filepath.Join(dir, name+".args"))
+	if err != nil {
+		t.Fatalf("stub %s was never invoked: %v", name, err)
+	}
+	return strings.Split(strings.TrimSpace(string(data)), "\n")
+}
+
+func stubWasNotInvoked(t *testing.T, dir, name string) {
+	t.Helper()
+
+	if _, err := os.Stat(filepath.Join(dir, name+".args")); err == nil {
+		t.Errorf("stub %s was invoked but should not have been", name)
+	}
+}
+
+// mysqlBackupConfig builds a config for the external MySQL path.
+func mysqlBackupConfig(format, compression, gcsPath string) ExecutorBackupConfig {
+	var cfg ExecutorBackupConfig
+	cfg.SourceType = "mysql"
+	cfg.Format = format
+	cfg.CompressionType = compression
+	cfg.Destination.GCSPath = gcsPath
+	cfg.Database.Username = "svc"
+	cfg.Database.Password = "hunter2"
+	return cfg
+}
+
+// ------------------------------------------------------- mysqldump wiring
+
+func TestExecuteExternalMySQLDumpBuildsItsArguments(t *testing.T) {
+	binDir := stubPATH(t)
+	stubBin(t, binDir, "mysqldump", "echo '-- dump'", 0)
+
+	e := newExecutor()
+	tempDir := t.TempDir()
+	outputPath := filepath.Join(tempDir, "orders.sql")
+
+	cfg := mysqlBackupConfig("sql", "", "gs://bucket/path")
+	if err := e.executeExternalMySQLDump(context.Background(),
+		"tokyo", "3306", "svc", "hunter2", "app", "orders", outputPath, cfg); err != nil {
+		t.Fatalf("executeExternalMySQLDump: %v", err)
+	}
+
+	args := stubArgs(t, binDir, "mysqldump")
+	joined := strings.Join(args, " ")
+	for _, want := range []string{
+		"--default-character-set=utf8mb4",
+		"-h", "tokyo",
+		"-P", "3306",
+		"-u", "svc",
+		"-phunter2",
+		"--single-transaction",
+		"--skip-lock-tables",
+		"--no-tablespaces",
+		"app", "orders",
+	} {
+		if !containsArg(args, want) {
+			t.Errorf("argument %q was not passed (got: %s)", want, joined)
+		}
+	}
+
+	// The dump is written to the output file, not swallowed.
+	data, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatalf("read output: %v", err)
+	}
+	if !strings.Contains(string(data), "-- dump") {
+		t.Errorf("output = %q, want the stub's stdout", data)
+	}
+}
+
+// The password is passed as -p<value> on the command line, so it is visible in
+// the process list to every user on the host for the duration of the dump.
+// maskMySQLPassword only masks the log line, not the argv.
+func TestTheMySQLPasswordIsPassedOnTheCommandLine(t *testing.T) {
+	binDir := stubPATH(t)
+	stubBin(t, binDir, "mysqldump", "", 0)
+
+	e := newExecutor()
+	outputPath := filepath.Join(t.TempDir(), "orders.sql")
+
+	if err := e.executeExternalMySQLDump(context.Background(),
+		"h", "3306", "svc", "hunter2", "app", "orders", outputPath,
+		mysqlBackupConfig("sql", "", "gs://b")); err != nil {
+		t.Fatalf("executeExternalMySQLDump: %v", err)
+	}
+
+	if !containsArg(stubArgs(t, binDir, "mysqldump"), "-phunter2") {
+		t.Fatalf("the password is no longer passed in argv — it appears to have moved to a file or the environment; assert the new mechanism instead")
+	}
+}
+
+func TestExecuteExternalMySQLDumpOmitsAnEmptyPassword(t *testing.T) {
+	binDir := stubPATH(t)
+	stubBin(t, binDir, "mysqldump", "", 0)
+
+	e := newExecutor()
+	outputPath := filepath.Join(t.TempDir(), "orders.sql")
+
+	if err := e.executeExternalMySQLDump(context.Background(),
+		"h", "3306", "svc", "", "app", "orders", outputPath,
+		mysqlBackupConfig("sql", "", "gs://b")); err != nil {
+		t.Fatalf("executeExternalMySQLDump: %v", err)
+	}
+
+	for _, a := range stubArgs(t, binDir, "mysqldump") {
+		if strings.HasPrefix(a, "-p") {
+			t.Errorf("an empty password produced %q", a)
+		}
+	}
+}
+
+func TestExecuteExternalMySQLDumpAppliesAWhereClause(t *testing.T) {
+	binDir := stubPATH(t)
+	stubBin(t, binDir, "mysqldump", "", 0)
+
+	e := newExecutor()
+	outputPath := filepath.Join(t.TempDir(), "orders.sql")
+
+	cfg := mysqlBackupConfig("sql", "", "gs://b")
+	cfg.Query = map[string]map[string]interface{}{
+		"orders": {"created_at": map[string]interface{}{
+			// The converter only understands this shape; the offsets must be
+			// float64, as they are after a JSON round trip.
+			"type": "daily", "startOffset": float64(-1), "endOffset": float64(0),
+		}},
+	}
+
+	if err := e.executeExternalMySQLDump(context.Background(),
+		"h", "3306", "svc", "pw", "app", "orders", outputPath, cfg); err != nil {
+		t.Fatalf("executeExternalMySQLDump: %v", err)
+	}
+
+	args := stubArgs(t, binDir, "mysqldump")
+	idx := indexOfArg(args, "--where")
+	if idx < 0 {
+		t.Fatalf("--where was not passed: %v", args)
+	}
+	if idx+1 >= len(args) {
+		t.Fatal("--where has no value")
+	}
+	where := args[idx+1]
+	if !strings.Contains(where, "created_at") {
+		t.Errorf("--where = %q, want it to mention created_at", where)
+	}
+}
+
+func TestExecuteExternalMySQLDumpReportsAFailingCommand(t *testing.T) {
+	binDir := stubPATH(t)
+	stubBin(t, binDir, "mysqldump", "echo 'access denied' >&2", 1)
+
+	e := newExecutor()
+	outputPath := filepath.Join(t.TempDir(), "orders.sql")
+
+	err := e.executeExternalMySQLDump(context.Background(),
+		"h", "3306", "svc", "pw", "app", "orders", outputPath,
+		mysqlBackupConfig("sql", "", "gs://b"))
+
+	if err == nil {
+		t.Fatal("executeExternalMySQLDump() = nil, want the non-zero exit")
+	}
+	if !strings.Contains(err.Error(), "mysqldump failed") {
+		t.Errorf("err = %v", err)
+	}
+}
+
+func TestExecuteExternalMySQLDumpReportsAnUncreatableOutput(t *testing.T) {
+	binDir := stubPATH(t)
+	stubBin(t, binDir, "mysqldump", "", 0)
+
+	e := newExecutor()
+	err := e.executeExternalMySQLDump(context.Background(),
+		"h", "3306", "svc", "pw", "app", "orders",
+		filepath.Join(t.TempDir(), "absent-dir", "orders.sql"),
+		mysqlBackupConfig("sql", "", "gs://b"))
+
+	if err == nil {
+		t.Fatal("executeExternalMySQLDump() = nil, want a file-creation error")
+	}
+	if !strings.Contains(err.Error(), "failed to create output file") {
+		t.Errorf("err = %v", err)
+	}
+	stubWasNotInvoked(t, binDir, "mysqldump")
+}
+
+// ------------------------------------------------------------- zip wiring
+
+func TestExecuteExternalZipBuildsItsArguments(t *testing.T) {
+	binDir := stubPATH(t)
+	workDir := t.TempDir()
+	input := filepath.Join(workDir, "orders.sql")
+	output := filepath.Join(workDir, "orders.zip")
+
+	if err := os.WriteFile(input, []byte("payload"), 0o600); err != nil {
+		t.Fatalf("write input: %v", err)
+	}
+	// The stub must produce the output file, which the caller then stats.
+	stubBin(t, binDir, "zip", "touch "+output, 0)
+
+	e := newExecutor()
+	if err := e.executeExternalZip(context.Background(), workDir, input, output); err != nil {
+		t.Fatalf("executeExternalZip: %v", err)
+	}
+
+	args := stubArgs(t, binDir, "zip")
+	if !containsArg(args, "-j") || !containsArg(args, output) || !containsArg(args, input) {
+		t.Errorf("args = %v, want -j plus both paths", args)
+	}
+}
+
+func TestExecuteExternalZipReportsAFailingCommand(t *testing.T) {
+	binDir := stubPATH(t)
+	stubBin(t, binDir, "zip", "echo 'disk full' >&2", 1)
+
+	e := newExecutor()
+	workDir := t.TempDir()
+	err := e.executeExternalZip(context.Background(), workDir,
+		filepath.Join(workDir, "in.sql"), filepath.Join(workDir, "out.zip"))
+
+	if err == nil {
+		t.Fatal("executeExternalZip() = nil, want the non-zero exit")
+	}
+	if !strings.Contains(err.Error(), "zip failed") || !strings.Contains(err.Error(), "disk full") {
+		t.Errorf("err = %v, want it to carry the command output", err)
+	}
+}
+
+// A zip command that exits 0 without producing the archive is caught by the
+// stat that follows, so a silently broken compression step does not pass as
+// success.
+func TestExecuteExternalZipRejectsAMissingArchive(t *testing.T) {
+	binDir := stubPATH(t)
+	stubBin(t, binDir, "zip", "", 0) // exits 0, writes nothing
+
+	e := newExecutor()
+	workDir := t.TempDir()
+	err := e.executeExternalZip(context.Background(), workDir,
+		filepath.Join(workDir, "in.sql"), filepath.Join(workDir, "out.zip"))
+
+	if err == nil {
+		t.Fatal("executeExternalZip() = nil despite no archive being produced")
+	}
+	if !strings.Contains(err.Error(), "zip output file not created") {
+		t.Errorf("err = %v", err)
+	}
+}
+
+// ------------------------------------------------------------ gsutil wiring
+
+func TestExecuteExternalGCSUploadBuildsItsArguments(t *testing.T) {
+	binDir := stubPATH(t)
+	stubBin(t, binDir, "gsutil", "", 0)
+
+	e := newExecutor()
+	if err := e.executeExternalGCSUpload(context.Background(),
+		"/tmp/orders.zip", "gs://bucket/path/orders.zip"); err != nil {
+		t.Fatalf("executeExternalGCSUpload: %v", err)
+	}
+
+	args := stubArgs(t, binDir, "gsutil")
+	if len(args) != 3 || args[0] != "cp" || args[1] != "/tmp/orders.zip" || args[2] != "gs://bucket/path/orders.zip" {
+		t.Errorf("args = %v, want [cp <local> <remote>]", args)
+	}
+}
+
+func TestExecuteExternalGCSUploadReportsAFailingCommand(t *testing.T) {
+	binDir := stubPATH(t)
+	stubBin(t, binDir, "gsutil", "echo 'AccessDeniedException: 403' >&2", 1)
+
+	e := newExecutor()
+	err := e.executeExternalGCSUpload(context.Background(), "/tmp/x.zip", "gs://b/x.zip")
+
+	if err == nil {
+		t.Fatal("executeExternalGCSUpload() = nil, want the non-zero exit")
+	}
+	if !strings.Contains(err.Error(), "gsutil upload failed") || !strings.Contains(err.Error(), "403") {
+		t.Errorf("err = %v, want it to carry the command output", err)
+	}
+}
+
+// The upload does not verify that the object landed: gsutil's exit status is
+// the only signal, and nothing reads back the object's size or checksum. A
+// truncated or empty archive uploads as a success.
+func TestTheUploadIsNotVerified(t *testing.T) {
+	binDir := stubPATH(t)
+	// Exits 0 without doing anything at all.
+	stubBin(t, binDir, "gsutil", "", 0)
+
+	e := newExecutor()
+	if err := e.executeExternalGCSUpload(context.Background(),
+		"/nonexistent/path/orders.zip", "gs://bucket/orders.zip"); err != nil {
+		t.Fatalf("executeExternalGCSUpload() = %v — the upload appears to be verified now; assert the verification instead", err)
+	}
+}
+
+// ------------------------------------------------- the full MySQL workflow
+
+func TestTheMySQLBackupWorkflowRunsAllThreeSteps(t *testing.T) {
+	binDir := stubPATH(t)
+	tempDir := t.TempDir()
+
+	stubBin(t, binDir, "mysqldump", "echo '-- dump'", 0)
+	// zip must produce its output for the stat check to pass.
+	stubBin(t, binDir, "zip", `for a in "$@"; do case "$a" in *.zip) touch "$a";; esac; done`, 0)
+	stubBin(t, binDir, "gsutil", "", 0)
+
+	e := newExecutor()
+	cfg := mysqlBackupConfig("sql", "", "gs://bucket/backups")
+
+	if err := e.executeExternalMySQLBackupSimple(context.Background(),
+		"mysql://svc:hunter2@tokyo:3306/app", "app", "orders", tempDir, cfg); err != nil {
+		t.Fatalf("executeExternalMySQLBackupSimple: %v", err)
+	}
+
+	stubArgs(t, binDir, "mysqldump")
+	stubArgs(t, binDir, "zip")
+	gsutil := stubArgs(t, binDir, "gsutil")
+	if !strings.HasPrefix(gsutil[2], "gs://bucket/backups/") {
+		t.Errorf("upload target = %q, want it under the configured GCS path", gsutil[2])
+	}
+	if !strings.HasSuffix(gsutil[2], ".zip") {
+		t.Errorf("upload target = %q, want a .zip", gsutil[2])
+	}
+
+	// Both intermediate files are removed afterwards.
+	entries, err := os.ReadDir(tempDir)
+	if err != nil {
+		t.Fatalf("read temp dir: %v", err)
+	}
+	for _, entry := range entries {
+		if strings.HasSuffix(entry.Name(), ".sql") || strings.HasSuffix(entry.Name(), ".zip") {
+			t.Errorf("temporary file %q was left behind", entry.Name())
+		}
+	}
+}
+
+func TestTheMySQLBackupWorkflowSkipsCompressionWhenDisabled(t *testing.T) {
+	binDir := stubPATH(t)
+	tempDir := t.TempDir()
+
+	stubBin(t, binDir, "mysqldump", "echo '-- dump'", 0)
+	stubBin(t, binDir, "zip", "", 0)
+	stubBin(t, binDir, "gsutil", "", 0)
+
+	e := newExecutor()
+	cfg := mysqlBackupConfig("sql", "none", "gs://bucket/backups")
+
+	if err := e.executeExternalMySQLBackupSimple(context.Background(),
+		"mysql://svc:pw@tokyo:3306/app", "app", "orders", tempDir, cfg); err != nil {
+		t.Fatalf("executeExternalMySQLBackupSimple: %v", err)
+	}
+
+	stubWasNotInvoked(t, binDir, "zip")
+
+	gsutil := stubArgs(t, binDir, "gsutil")
+	if !strings.HasSuffix(gsutil[2], ".sql") {
+		t.Errorf("upload target = %q, want the uncompressed .sql", gsutil[2])
+	}
+}
+
+func TestTheMySQLBackupWorkflowRejectsAnUnsupportedFormat(t *testing.T) {
+	stubPATH(t)
+
+	e := newExecutor()
+	err := e.executeExternalMySQLBackupSimple(context.Background(),
+		"mysql://svc:pw@h:3306/app", "app", "orders", t.TempDir(),
+		mysqlBackupConfig("parquet", "", "gs://b"))
+
+	if err == nil {
+		t.Fatal("an unsupported format was accepted")
+	}
+	if !strings.Contains(err.Error(), "unsupported format") {
+		t.Errorf("err = %v", err)
+	}
+}
+
+func TestTheMySQLBackupWorkflowStopsWhenTheDumpFails(t *testing.T) {
+	binDir := stubPATH(t)
+	stubBin(t, binDir, "mysqldump", "echo 'denied' >&2", 1)
+	stubBin(t, binDir, "zip", "", 0)
+	stubBin(t, binDir, "gsutil", "", 0)
+
+	e := newExecutor()
+	err := e.executeExternalMySQLBackupSimple(context.Background(),
+		"mysql://svc:pw@h:3306/app", "app", "orders", t.TempDir(),
+		mysqlBackupConfig("sql", "", "gs://b"))
+
+	if err == nil {
+		t.Fatal("the workflow reported success despite a failing dump")
+	}
+	if !strings.Contains(err.Error(), "external MySQL export failed") {
+		t.Errorf("err = %v", err)
+	}
+	stubWasNotInvoked(t, binDir, "zip")
+	stubWasNotInvoked(t, binDir, "gsutil")
+}
+
+func TestTheMySQLBackupWorkflowStopsWhenTheUploadFails(t *testing.T) {
+	binDir := stubPATH(t)
+	tempDir := t.TempDir()
+
+	stubBin(t, binDir, "mysqldump", "echo '-- dump'", 0)
+	stubBin(t, binDir, "zip", `for a in "$@"; do case "$a" in *.zip) touch "$a";; esac; done`, 0)
+	stubBin(t, binDir, "gsutil", "echo '403' >&2", 1)
+
+	e := newExecutor()
+	err := e.executeExternalMySQLBackupSimple(context.Background(),
+		"mysql://svc:pw@h:3306/app", "app", "orders", tempDir,
+		mysqlBackupConfig("sql", "", "gs://b"))
+
+	if err == nil {
+		t.Fatal("the workflow reported success despite a failing upload")
+	}
+	if !strings.Contains(err.Error(), "external GCS upload failed") {
+		t.Errorf("err = %v", err)
+	}
+}
+
+// When the upload fails the intermediate .sql and .zip are left in the
+// temporary directory: the cleanup only runs on the success path. A backup
+// target that is unreachable for a while therefore fills the disk one dump at
+// a time.
+func TestAFailedUploadLeavesTheIntermediateFilesBehind(t *testing.T) {
+	binDir := stubPATH(t)
+	tempDir := t.TempDir()
+
+	stubBin(t, binDir, "mysqldump", "echo '-- dump'", 0)
+	stubBin(t, binDir, "zip", `for a in "$@"; do case "$a" in *.zip) touch "$a";; esac; done`, 0)
+	stubBin(t, binDir, "gsutil", "echo '403' >&2", 1)
+
+	e := newExecutor()
+	_ = e.executeExternalMySQLBackupSimple(context.Background(),
+		"mysql://svc:pw@h:3306/app", "app", "orders", tempDir,
+		mysqlBackupConfig("sql", "", "gs://b"))
+
+	entries, err := os.ReadDir(tempDir)
+	if err != nil {
+		t.Fatalf("read temp dir: %v", err)
+	}
+	var left []string
+	for _, entry := range entries {
+		if strings.HasSuffix(entry.Name(), ".sql") || strings.HasSuffix(entry.Name(), ".zip") {
+			left = append(left, entry.Name())
+		}
+	}
+	if len(left) == 0 {
+		t.Fatalf("nothing was left behind — the cleanup appears to run on the failure path now; assert the cleanup instead")
+	}
+	t.Logf("left behind after a failed upload: %v", left)
+}
+
+func containsArg(args []string, want string) bool {
+	for _, a := range args {
+		if a == want {
+			return true
+		}
+	}
+	return false
+}
+
+func indexOfArg(args []string, want string) int {
+	for i, a := range args {
+		if a == want {
+			return i
+		}
+	}
+	return -1
+}
+
+// ------------------------------------------------ mongoexport workflow
+
+func mongoBackupConfig(gcsPath string) ExecutorBackupConfig {
+	var cfg ExecutorBackupConfig
+	cfg.SourceType = "mongodb"
+	cfg.Destination.GCSPath = gcsPath
+	return cfg
+}
+
+// zipStubBody produces the .zip argument it is handed, which the caller stats.
+const zipStubBody = `for a in "$@"; do case "$a" in *.zip) touch "$a";; esac; done`
+
+// mongoexportStubBody produces the --out file, which mongoexport writes itself
+// (unlike mysqldump, whose stdout the caller redirects).
+const mongoexportStubBody = `for a in "$@"; do case "$a" in *.json) touch "$a";; esac; done`
+
+func TestTheMongoBackupWorkflowRunsAllThreeSteps(t *testing.T) {
+	binDir := stubPATH(t)
+	tempDir := t.TempDir()
+
+	stubBin(t, binDir, "mongoexport", mongoexportStubBody, 0)
+	stubBin(t, binDir, "zip", zipStubBody, 0)
+	stubBin(t, binDir, "gsutil", "", 0)
+
+	e := newExecutor()
+	if err := e.executeExternalMongoExportSimple(context.Background(),
+		"mongodb://tokyo:27017/app", "app", "orders", tempDir,
+		mongoBackupConfig("gs://bucket/backups")); err != nil {
+		t.Fatalf("executeExternalMongoExportSimple: %v", err)
+	}
+
+	stubArgs(t, binDir, "mongoexport")
+	stubArgs(t, binDir, "zip")
+
+	gsutil := stubArgs(t, binDir, "gsutil")
+	if !strings.HasPrefix(gsutil[2], "gs://bucket/backups/") || !strings.HasSuffix(gsutil[2], ".zip") {
+		t.Errorf("upload target = %q, want a .zip under the configured GCS path", gsutil[2])
+	}
+
+	// Both intermediates are removed on the success path.
+	entries, err := os.ReadDir(tempDir)
+	if err != nil {
+		t.Fatalf("read temp dir: %v", err)
+	}
+	for _, entry := range entries {
+		if strings.HasSuffix(entry.Name(), ".json") || strings.HasSuffix(entry.Name(), ".zip") {
+			t.Errorf("temporary file %q was left behind", entry.Name())
+		}
+	}
+}
+
+func TestTheMongoBackupWorkflowStopsWhenTheExportFails(t *testing.T) {
+	binDir := stubPATH(t)
+	stubBin(t, binDir, "mongoexport", "echo 'auth failed' >&2", 1)
+	stubBin(t, binDir, "zip", zipStubBody, 0)
+	stubBin(t, binDir, "gsutil", "", 0)
+
+	e := newExecutor()
+	err := e.executeExternalMongoExportSimple(context.Background(),
+		"mongodb://h:27017/app", "app", "orders", t.TempDir(), mongoBackupConfig("gs://b"))
+
+	if err == nil {
+		t.Fatal("the workflow reported success despite a failing export")
+	}
+	if !strings.Contains(err.Error(), "external mongoexport failed") {
+		t.Errorf("err = %v", err)
+	}
+	stubWasNotInvoked(t, binDir, "zip")
+	stubWasNotInvoked(t, binDir, "gsutil")
+}
+
+func TestTheMongoBackupWorkflowStopsWhenTheZipFails(t *testing.T) {
+	binDir := stubPATH(t)
+	stubBin(t, binDir, "mongoexport", mongoexportStubBody, 0)
+	stubBin(t, binDir, "zip", "echo 'disk full' >&2", 1)
+	stubBin(t, binDir, "gsutil", "", 0)
+
+	e := newExecutor()
+	err := e.executeExternalMongoExportSimple(context.Background(),
+		"mongodb://h:27017/app", "app", "orders", t.TempDir(), mongoBackupConfig("gs://b"))
+
+	if err == nil {
+		t.Fatal("the workflow reported success despite a failing zip")
+	}
+	if !strings.Contains(err.Error(), "external zip failed") {
+		t.Errorf("err = %v", err)
+	}
+	stubWasNotInvoked(t, binDir, "gsutil")
+}
+
+func TestExecuteExternalMongoExportWithOptionsPassesTheConnection(t *testing.T) {
+	binDir := stubPATH(t)
+	stubBin(t, binDir, "mongoexport", mongoexportStubBody, 0)
+
+	e := newExecutor()
+	outputPath := filepath.Join(t.TempDir(), "orders.json")
+
+	if err := e.executeExternalMongoExportWithOptions(context.Background(),
+		"mongodb://tokyo:27017/app", "app", "orders", outputPath,
+		mongoBackupConfig("gs://b")); err != nil {
+		t.Fatalf("executeExternalMongoExportWithOptions: %v", err)
+	}
+
+	args := stubArgs(t, binDir, "mongoexport")
+	joined := strings.Join(args, " ")
+	if !strings.Contains(joined, "mongodb://tokyo:27017/app") {
+		t.Errorf("the connection string was not passed: %s", joined)
+	}
+	if !strings.Contains(joined, "orders") {
+		t.Errorf("the collection was not passed: %s", joined)
+	}
+	if !strings.Contains(joined, outputPath) {
+		t.Errorf("the output path was not passed: %s", joined)
+	}
+}
+
+func TestExecuteExternalMongoExportWithOptionsAppliesAQuery(t *testing.T) {
+	binDir := stubPATH(t)
+	stubBin(t, binDir, "mongoexport", mongoexportStubBody, 0)
+
+	e := newExecutor()
+	cfg := mongoBackupConfig("gs://b")
+	cfg.Query = map[string]map[string]interface{}{
+		"orders": {"created_at": map[string]interface{}{
+			"type": "daily", "startOffset": float64(-1), "endOffset": float64(0),
+		}},
+	}
+
+	if err := e.executeExternalMongoExportWithOptions(context.Background(),
+		"mongodb://h:27017/app", "app", "orders",
+		filepath.Join(t.TempDir(), "orders.json"), cfg); err != nil {
+		t.Fatalf("executeExternalMongoExportWithOptions: %v", err)
+	}
+
+	joined := strings.Join(stubArgs(t, binDir, "mongoexport"), " ")
+	if !strings.Contains(joined, "created_at") {
+		t.Errorf("the query was not passed: %s", joined)
+	}
+}
+
+// -------------------------------------------------------- CSV export path
+
+func TestExecuteExternalMySQLCSVPipesThroughPython(t *testing.T) {
+	binDir := stubPATH(t)
+	// mysql emits two TSV rows; the real python3 converts them to CSV.
+	stubBin(t, binDir, "mysql", `printf 'id\tname\n1\talice\n'`, 0)
+	linkRealBinary(t, binDir, "python3")
+
+	e := newExecutor()
+	outputPath := filepath.Join(t.TempDir(), "orders.csv")
+
+	if err := e.executeExternalMySQLCSV(context.Background(),
+		"h", "3306", "svc", "hunter2", "app", "orders", outputPath,
+		mysqlBackupConfig("csv", "", "gs://b")); err != nil {
+		t.Fatalf("executeExternalMySQLCSV: %v", err)
+	}
+
+	args := stubArgs(t, binDir, "mysql")
+	for _, want := range []string{"--default-character-set=utf8mb4", "-h", "h", "-P", "3306", "-u", "svc", "-phunter2", "app", "-e", "--batch"} {
+		if !containsArg(args, want) {
+			t.Errorf("argument %q was not passed (got: %v)", want, args)
+		}
+	}
+
+	data, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatalf("read output: %v", err)
+	}
+	// QUOTE_ALL means every field is quoted.
+	if !strings.Contains(string(data), `"id","name"`) || !strings.Contains(string(data), `"1","alice"`) {
+		t.Errorf("output = %q, want quoted CSV rows", data)
+	}
+}
+
+// MySQL's batch mode marks NULL as \N; the python converter turns it into an
+// empty field, which is indistinguishable from an empty string in the CSV.
+func TestCSVExportCannotDistinguishNullFromEmpty(t *testing.T) {
+	binDir := stubPATH(t)
+	stubBin(t, binDir, "mysql", `printf 'a\tb\n\\N\t\n'`, 0)
+	linkRealBinary(t, binDir, "python3")
+
+	e := newExecutor()
+	outputPath := filepath.Join(t.TempDir(), "orders.csv")
+
+	if err := e.executeExternalMySQLCSV(context.Background(),
+		"h", "3306", "svc", "pw", "app", "orders", outputPath,
+		mysqlBackupConfig("csv", "", "gs://b")); err != nil {
+		t.Fatalf("executeExternalMySQLCSV: %v", err)
+	}
+
+	data, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatalf("read output: %v", err)
+	}
+	if !strings.Contains(string(data), `"",""`) {
+		t.Fatalf("output = %q — NULL appears to be distinguishable now; assert the new encoding instead", data)
+	}
+}
+
+func TestExecuteExternalMySQLCSVReportsAFailingQuery(t *testing.T) {
+	binDir := stubPATH(t)
+	stubBin(t, binDir, "mysql", "echo 'ERROR 1146: no such table' >&2", 1)
+	linkRealBinary(t, binDir, "python3")
+
+	e := newExecutor()
+	err := e.executeExternalMySQLCSV(context.Background(),
+		"h", "3306", "svc", "pw", "app", "orders",
+		filepath.Join(t.TempDir(), "orders.csv"),
+		mysqlBackupConfig("csv", "", "gs://b"))
+
+	if err == nil {
+		t.Fatal("executeExternalMySQLCSV() = nil, want the non-zero exit")
+	}
+}
+
+func TestTheMySQLBackupWorkflowUsesTheCSVPath(t *testing.T) {
+	binDir := stubPATH(t)
+	tempDir := t.TempDir()
+
+	stubBin(t, binDir, "mysql", `printf 'id\n1\n'`, 0)
+	linkRealBinary(t, binDir, "python3")
+	stubBin(t, binDir, "zip", zipStubBody, 0)
+	stubBin(t, binDir, "gsutil", "", 0)
+
+	e := newExecutor()
+	if err := e.executeExternalMySQLBackupSimple(context.Background(),
+		"mysql://svc:pw@h:3306/app", "app", "orders", tempDir,
+		mysqlBackupConfig("csv", "", "gs://bucket/backups")); err != nil {
+		t.Fatalf("executeExternalMySQLBackupSimple: %v", err)
+	}
+
+	stubWasNotInvoked(t, binDir, "mysqldump")
+	stubArgs(t, binDir, "mysql")
+
+	gsutil := stubArgs(t, binDir, "gsutil")
+	if !strings.HasSuffix(gsutil[2], ".zip") {
+		t.Errorf("upload target = %q, want a .zip", gsutil[2])
+	}
+}
+
+// linkRealBinary symlinks a real system binary into the stub directory, for
+// commands a test needs to actually run rather than stub.
+func linkRealBinary(t *testing.T, dir, name string) {
+	t.Helper()
+
+	for _, candidate := range []string{"/usr/bin/" + name, "/bin/" + name, "/usr/local/bin/" + name} {
+		if _, err := os.Stat(candidate); err == nil {
+			if err := os.Symlink(candidate, filepath.Join(dir, name)); err != nil {
+				t.Fatalf("symlink %s: %v", name, err)
+			}
+			return
+		}
+	}
+	t.Skipf("%s is not installed", name)
+}

--- a/pkg/backup/external_simple_test.go
+++ b/pkg/backup/external_simple_test.go
@@ -1,0 +1,236 @@
+package backup
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestMaskSensitiveArgs(t *testing.T) {
+	// The masker has to match the argument form the callers build, which is
+	// "--uri" followed by the connection string as a separate argument.
+	got := newExecutor().maskSensitiveArgs([]string{
+		"mongoexport", "--uri", "mongodb://root:secret@db:27017/?authSource=admin",
+		"--collection", "orders",
+	})
+
+	if strings.Contains(got, "secret") || strings.Contains(got, "root") {
+		t.Errorf("masked command still contains credentials: %q", got)
+	}
+	if !strings.Contains(got, "mongodb://***:***@db:27017/?authSource=admin") {
+		t.Errorf("masked command = %q, want the host part preserved", got)
+	}
+	for _, want := range []string{"mongoexport", "--collection orders"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("masked command = %q, want it to contain %q", got, want)
+		}
+	}
+}
+
+func TestMaskSensitiveArgsLeavesOtherFormsAlone(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+	}{
+		// No credentials to hide.
+		{"uri without credentials", []string{"--uri", "mongodb://db:27017/"}},
+		// A username with no password has no colon in the credential part, so
+		// the branch does not fire; only the username is exposed.
+		{"username only", []string{"--uri", "mongodb://root@db:27017/"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := newExecutor().maskSensitiveArgs(tt.args)
+			if got != strings.Join(tt.args, " ") {
+				t.Errorf("maskSensitiveArgs = %q, want it unchanged", got)
+			}
+		})
+	}
+}
+
+func TestMaskSensitiveArgsLeavesInputUnchanged(t *testing.T) {
+	args := []string{"--uri", "mongodb://root:secret@db:27017/"}
+
+	newExecutor().maskSensitiveArgs(args)
+
+	if args[1] != "mongodb://root:secret@db:27017/" {
+		t.Errorf("the input slice was mutated: %v", args)
+	}
+}
+
+func mongoBounds(t *testing.T, converted map[string]interface{}, field string) (time.Time, time.Time) {
+	t.Helper()
+
+	q, ok := converted[field].(map[string]interface{})
+	if !ok {
+		t.Fatalf("%s was not converted: %#v", field, converted[field])
+	}
+	read := func(op string) time.Time {
+		bound, ok := q[op].(map[string]interface{})
+		if !ok {
+			t.Fatalf("%s has no %s object: %#v", field, op, q)
+		}
+		s, ok := bound["$date"].(string)
+		if !ok {
+			t.Fatalf("%s %s has no $date string: %#v", field, op, bound)
+		}
+		ts, err := time.Parse("2006-01-02T15:04:05.000Z", s)
+		if err != nil {
+			t.Fatalf("%s %s date %q does not parse: %v", field, op, s, err)
+		}
+		return ts
+	}
+	return read("$gte"), read("$lt")
+}
+
+func TestConvertTimeRangeQuery(t *testing.T) {
+	got := newExecutor().convertTimeRangeQuery(
+		map[string]interface{}{"created_at": dailyQuery(float64(-1), float64(0))})
+
+	start, end := mongoBounds(t, got, "created_at")
+
+	// JST midnight rendered in UTC is 15:00 on the preceding day.
+	for name, ts := range map[string]time.Time{"$gte": start, "$lt": end} {
+		if ts.Hour() != 15 || ts.Minute() != 0 || ts.Second() != 0 {
+			t.Errorf("%s = %v, want 15:00:00", name, ts)
+		}
+	}
+	if span := end.Sub(start); span != 24*time.Hour {
+		t.Errorf("range spans %v, want 24h", span)
+	}
+}
+
+// TestMongoAndMySQLTimeRangesAgree pins the other half of T-022. The MongoDB
+// and MySQL query builders are separate copies of the same logic, and they do
+// agree with each other — both use time.Date in JST and treat endOffset as
+// exclusive. Only the table-selection window in extractTimeRange is the
+// outlier, which is what makes it worth reconciling rather than the other two.
+func TestMongoAndMySQLTimeRangesAgree(t *testing.T) {
+	query := map[string]interface{}{"created_at": dailyQuery(float64(-3), float64(-1))}
+
+	mongoStart, mongoEnd := mongoBounds(t, newExecutor().convertTimeRangeQuery(query), "created_at")
+	mysqlStart, mysqlEnd := parseWhereBounds(t, newExecutor().convertTimeRangeQueryForMySQL(query))
+
+	if !mongoStart.Equal(mysqlStart) || !mongoEnd.Equal(mysqlEnd) {
+		t.Errorf("mongo window %v..%v differs from mysql window %v..%v",
+			mongoStart, mongoEnd, mysqlStart, mysqlEnd)
+	}
+	if span := mongoEnd.Sub(mongoStart); span != 48*time.Hour {
+		t.Errorf("range spans %v, want 48h for offsets -3..-1", span)
+	}
+}
+
+func TestConvertTimeRangeQueryPassesThroughOtherEntries(t *testing.T) {
+	input := map[string]interface{}{
+		"status":     "active",
+		"score":      float64(3),
+		"weekly":     map[string]interface{}{"type": "weekly"},
+		"plain":      map[string]interface{}{"$gt": float64(1)},
+		"created_at": dailyQuery(float64(-1), float64(0)),
+	}
+
+	got := newExecutor().convertTimeRangeQuery(input)
+
+	for _, key := range []string{"status", "score", "weekly", "plain"} {
+		if !reflect.DeepEqual(got[key], input[key]) {
+			t.Errorf("%s = %#v, want it passed through unchanged", key, got[key])
+		}
+	}
+	if _, converted := got["created_at"].(map[string]interface{})["$gte"]; !converted {
+		t.Error("created_at was not converted")
+	}
+}
+
+// TestConvertTimeRangeQueryEqualOffsetsMatchNothing mirrors the MySQL variant:
+// endOffset is exclusive, so 0..0 yields $gte and $lt at the same instant and
+// the export writes an empty file without reporting anything.
+func TestConvertTimeRangeQueryEqualOffsetsMatchNothing(t *testing.T) {
+	got := newExecutor().convertTimeRangeQuery(
+		map[string]interface{}{"created_at": dailyQuery(float64(0), float64(0))})
+
+	start, end := mongoBounds(t, got, "created_at")
+
+	if !start.Equal(end) {
+		t.Errorf("bounds are %v..%v; equal offsets no longer collapse the range, "+
+			"so assert the new behaviour instead", start, end)
+	}
+}
+
+func TestCleanQueryStringValues(t *testing.T) {
+	tests := []struct {
+		name  string
+		input map[string]interface{}
+		want  map[string]interface{}
+	}{
+		{
+			"double quotes are stripped",
+			map[string]interface{}{"status": `"active"`},
+			map[string]interface{}{"status": "active"},
+		},
+		{
+			"single quotes are stripped",
+			map[string]interface{}{"status": `'active'`},
+			map[string]interface{}{"status": "active"},
+		},
+		{
+			"both layers are stripped in one pass",
+			map[string]interface{}{"status": `"'active'"`},
+			map[string]interface{}{"status": "active"},
+		},
+		{
+			"unquoted values are untouched",
+			map[string]interface{}{"status": "active"},
+			map[string]interface{}{"status": "active"},
+		},
+		{
+			"non-strings are untouched",
+			map[string]interface{}{"score": float64(1), "ok": true, "none": nil},
+			map[string]interface{}{"score": float64(1), "ok": true, "none": nil},
+		},
+		{
+			"nested objects are cleaned recursively",
+			map[string]interface{}{"user": map[string]interface{}{"name": `"jack"`}},
+			map[string]interface{}{"user": map[string]interface{}{"name": "jack"}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := cleanQueryStringValues(tt.input); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("cleanQueryStringValues = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestCleanQueryStringValuesCorruptsLegitimateQuotes records a defect: the
+// function only checks that a value starts and ends with a quote, without
+// verifying that they are a matching pair. A value that legitimately opens and
+// closes with quoted words loses its outer characters, and a value consisting
+// of a single quote character is emptied entirely.
+func TestCleanQueryStringValuesCorruptsLegitimateQuotes(t *testing.T) {
+	tests := []struct {
+		name     string
+		in, want string
+	}{
+		{"quoted words at both ends", `"hello" and "world"`, `hello" and "world`},
+		{"a lone double quote becomes empty", `"`, ""},
+		{"a lone single quote becomes empty", `'`, ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := cleanQueryStringValues(map[string]interface{}{"v": tt.in})["v"]
+
+			if got == tt.in {
+				t.Fatalf("value %q is now left alone; the quote handling may have "+
+					"been fixed, so assert that instead", tt.in)
+			}
+			if got != tt.want {
+				t.Errorf("cleanQueryStringValues(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/backup/file_io_test.go
+++ b/pkg/backup/file_io_test.go
@@ -1,0 +1,493 @@
+package backup
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestNewBackupExecutorKeepsItsHandle(t *testing.T) {
+	if e := NewBackupExecutor(nil); e == nil {
+		t.Fatal("NewBackupExecutor returned nil")
+	} else if e.db != nil {
+		t.Errorf("db = %v, want nil", e.db)
+	}
+}
+
+func TestCopyFile(t *testing.T) {
+	e := newExecutor()
+	dir := t.TempDir()
+
+	src := filepath.Join(dir, "src.json")
+	want := bytes.Repeat([]byte("payload\n"), 20000) // larger than the 64KB buffer
+	if err := os.WriteFile(src, want, 0o600); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+
+	dst := filepath.Join(dir, "nested", "deeper", "dst.json")
+	if err := e.copyFile(src, dst); err != nil {
+		t.Fatalf("copyFile: %v", err)
+	}
+
+	got, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatalf("read destination: %v", err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Errorf("the copy is %d bytes, want %d", len(got), len(want))
+	}
+}
+
+func TestCopyFileCreatesTheDestinationDirectory(t *testing.T) {
+	e := newExecutor()
+	dir := t.TempDir()
+
+	src := filepath.Join(dir, "src")
+	if err := os.WriteFile(src, []byte("x"), 0o600); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+
+	dst := filepath.Join(dir, "a", "b", "c", "dst")
+	if err := e.copyFile(src, dst); err != nil {
+		t.Fatalf("copyFile: %v", err)
+	}
+	if _, err := os.Stat(filepath.Dir(dst)); err != nil {
+		t.Errorf("the destination directory was not created: %v", err)
+	}
+}
+
+func TestCopyFileReportsAMissingSource(t *testing.T) {
+	e := newExecutor()
+	dir := t.TempDir()
+
+	if err := e.copyFile(filepath.Join(dir, "absent"), filepath.Join(dir, "dst")); err == nil {
+		t.Error("copyFile() = nil, want an error for a missing source")
+	}
+}
+
+func TestCopyFileOverwritesTheDestination(t *testing.T) {
+	e := newExecutor()
+	dir := t.TempDir()
+
+	src := filepath.Join(dir, "src")
+	dst := filepath.Join(dir, "dst")
+	if err := os.WriteFile(src, []byte("new"), 0o600); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	if err := os.WriteFile(dst, []byte("this is the old and longer content"), 0o600); err != nil {
+		t.Fatalf("write destination: %v", err)
+	}
+
+	if err := e.copyFile(src, dst); err != nil {
+		t.Fatalf("copyFile: %v", err)
+	}
+	got, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatalf("read destination: %v", err)
+	}
+	if string(got) != "new" {
+		t.Errorf("destination = %q, want %q — the old content was not truncated", got, "new")
+	}
+}
+
+func TestWriteAndReadJSONFileRoundTrip(t *testing.T) {
+	e := newExecutor()
+	dir := t.TempDir()
+
+	docs := []interface{}{
+		map[string]interface{}{"_id": "1", "name": "alice"},
+		map[string]interface{}{"_id": "2", "name": "bob"},
+	}
+
+	path := filepath.Join(dir, "orders_2026-08-20.json")
+	if err := e.writeJSONFile(path, docs); err != nil {
+		t.Fatalf("writeJSONFile: %v", err)
+	}
+
+	// One JSON object per line, JSONL.
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if n := len(strings.Split(strings.TrimSpace(string(raw)), "\n")); n != 2 {
+		t.Errorf("the file has %d lines, want 2 (content: %q)", n, raw)
+	}
+
+	got, err := e.readJSONFile(dir, "orders", "2026-08-20")
+	if err != nil {
+		t.Fatalf("readJSONFile: %v", err)
+	}
+	if !reflect.DeepEqual(got, docs) {
+		t.Errorf("round trip = %#v, want %#v", got, docs)
+	}
+}
+
+func TestWriteJSONFileOnAnEmptySlice(t *testing.T) {
+	e := newExecutor()
+	path := filepath.Join(t.TempDir(), "empty.json")
+
+	if err := e.writeJSONFile(path, nil); err != nil {
+		t.Fatalf("writeJSONFile: %v", err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if info.Size() != 0 {
+		t.Errorf("the file is %d bytes, want 0", info.Size())
+	}
+}
+
+func TestWriteJSONFileRejectsAnUnmarshalableDocument(t *testing.T) {
+	e := newExecutor()
+	path := filepath.Join(t.TempDir(), "bad.json")
+
+	err := e.writeJSONFile(path, []interface{}{make(chan int)})
+	if err == nil {
+		t.Fatal("writeJSONFile() = nil, want a marshal error")
+	}
+	if !strings.Contains(err.Error(), "marshal") {
+		t.Errorf("err = %v, want it to mention marshalling", err)
+	}
+}
+
+func TestWriteJSONFileReportsAnUncreatableTarget(t *testing.T) {
+	e := newExecutor()
+
+	err := e.writeJSONFile(filepath.Join(t.TempDir(), "absent-dir", "x.json"), nil)
+	if err == nil {
+		t.Fatal("writeJSONFile() = nil, want an error — the parent directory does not exist")
+	}
+}
+
+func TestReadJSONFileReportsAMissingFile(t *testing.T) {
+	e := newExecutor()
+
+	_, err := e.readJSONFile(t.TempDir(), "orders", "2026-08-20")
+	if err == nil {
+		t.Fatal("readJSONFile() = nil, want an error for a missing file")
+	}
+	if !strings.Contains(err.Error(), "failed to read file") {
+		t.Errorf("err = %v", err)
+	}
+}
+
+func TestReadJSONFileSkipsBlankLines(t *testing.T) {
+	e := newExecutor()
+	dir := t.TempDir()
+
+	body := "{\"a\":1}\n\n   \n{\"a\":2}\n"
+	if err := os.WriteFile(filepath.Join(dir, "t_2026-08-20.json"), []byte(body), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	got, err := e.readJSONFile(dir, "t", "2026-08-20")
+	if err != nil {
+		t.Fatalf("readJSONFile: %v", err)
+	}
+	if len(got) != 2 {
+		t.Errorf("read %d documents, want 2", len(got))
+	}
+}
+
+// A line that does not parse is logged at warn level and dropped, and the read
+// still returns success. A truncated or partially corrupt mongoexport is
+// therefore restored with documents silently missing — the caller has no way
+// to tell how many were lost.
+func TestReadJSONFileSilentlyDropsCorruptLines(t *testing.T) {
+	e := newExecutor()
+	dir := t.TempDir()
+
+	body := "{\"id\":1}\n{\"id\":2,\n{\"id\":3}\nnot json at all\n{\"id\":5}\n"
+	if err := os.WriteFile(filepath.Join(dir, "t_2026-08-20.json"), []byte(body), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	got, err := e.readJSONFile(dir, "t", "2026-08-20")
+	if err != nil {
+		t.Fatalf("readJSONFile() = %v — corrupt lines appear to be reported now; assert the error instead", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("read %d documents from 5 lines, want 3 — the drop behaviour appears to have changed", len(got))
+	}
+}
+
+func TestCountRecordsInFile(t *testing.T) {
+	e := newExecutor()
+	dir := t.TempDir()
+
+	path := filepath.Join(dir, "t.json")
+	body := "{\"id\":1}\n{\"id\":2}\n\n{\"id\":3}\n"
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	count, sizeMB, err := e.countRecordsInFile(path)
+	if err != nil {
+		t.Fatalf("countRecordsInFile: %v", err)
+	}
+	if count != 3 {
+		t.Errorf("count = %d, want 3", count)
+	}
+	if want := float64(len(body)) / 1024 / 1024; sizeMB != want {
+		t.Errorf("sizeMB = %v, want %v", sizeMB, want)
+	}
+}
+
+func TestCountRecordsInFileReportsAMissingFile(t *testing.T) {
+	e := newExecutor()
+
+	if _, _, err := e.countRecordsInFile(filepath.Join(t.TempDir(), "absent")); err == nil {
+		t.Error("countRecordsInFile() = nil, want an error")
+	}
+}
+
+// The count is "lines beginning with {", so anything else in the export is
+// invisible: a pretty-printed document counts once for its opening brace and
+// zero for its remaining lines, and a JSON array wrapper counts as zero
+// records. The number is only correct for the JSONL that mongoexport emits by
+// default.
+func TestCountRecordsMiscountsNonJSONL(t *testing.T) {
+	e := newExecutor()
+	dir := t.TempDir()
+
+	pretty := filepath.Join(dir, "pretty.json")
+	if err := os.WriteFile(pretty, []byte("{\n  \"id\": 1\n}\n{\n  \"id\": 2\n}\n"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	count, _, err := e.countRecordsInFile(pretty)
+	if err != nil {
+		t.Fatalf("countRecordsInFile: %v", err)
+	}
+	if count != 2 {
+		t.Fatalf("pretty-printed: count = %d — the counter appears to parse JSON now", count)
+	}
+
+	array := filepath.Join(dir, "array.json")
+	if err := os.WriteFile(array, []byte("[\n{\"id\":1},\n{\"id\":2}\n]\n"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	count, _, err = e.countRecordsInFile(array)
+	if err != nil {
+		t.Fatalf("countRecordsInFile: %v", err)
+	}
+	if count != 2 {
+		t.Fatalf("array-wrapped: count = %d, want 2 (the brace lines) — the counter appears to parse JSON now", count)
+	}
+}
+
+// A JSONL line longer than the 1MB scanner buffer aborts the count with an
+// error rather than being counted. MongoDB documents may be up to 16MB, so a
+// single large document makes the record count for the whole file unavailable.
+func TestCountRecordsFailsOnADocumentLargerThanOneMegabyte(t *testing.T) {
+	e := newExecutor()
+	path := filepath.Join(t.TempDir(), "big.json")
+
+	big := fmt.Sprintf(`{"blob":"%s"}`, strings.Repeat("x", 2*1024*1024))
+	if err := os.WriteFile(path, []byte(big+"\n"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	_, _, err := e.countRecordsInFile(path)
+	if err == nil {
+		t.Fatalf("countRecordsInFile() = nil — the buffer appears to have been raised; assert the count instead")
+	}
+	if !strings.Contains(err.Error(), "too long") {
+		t.Errorf("err = %v, want a token-too-long error", err)
+	}
+}
+
+func TestUseExternalCommandsHonoursTheEnvironmentVariable(t *testing.T) {
+	e := newExecutor()
+
+	t.Setenv("USE_EXTERNAL_BACKUP", "true")
+	if !e.UseExternalCommands() {
+		t.Error("UseExternalCommands() = false with USE_EXTERNAL_BACKUP=true")
+	}
+
+	t.Setenv("USE_EXTERNAL_BACKUP", "")
+	if e.UseExternalCommands() {
+		t.Error("UseExternalCommands() = true with the variable unset and low memory use")
+	}
+}
+
+// The switch is an exact string comparison against "true", so the spellings
+// operators normally use are silently ignored and the memory-hungry in-process
+// path is taken instead.
+func TestUseExternalCommandsRejectsOtherTruthySpellings(t *testing.T) {
+	e := newExecutor()
+
+	for _, value := range []string{"1", "TRUE", "True", "yes", "on", " true"} {
+		t.Setenv("USE_EXTERNAL_BACKUP", value)
+		if e.UseExternalCommands() {
+			t.Fatalf("USE_EXTERNAL_BACKUP=%q is now accepted — the parsing appears to have been widened", value)
+		}
+	}
+}
+
+func TestExecuteCommandOnASuccessfulProcess(t *testing.T) {
+	if _, err := exec.LookPath("sh"); err != nil {
+		t.Skip("sh is not available")
+	}
+
+	cmd := exec.Command("sh", "-c", "echo exported 12 records; exit 0")
+	if err := executeCommand(cmd, "mongoexport"); err != nil {
+		t.Errorf("executeCommand() = %v, want nil", err)
+	}
+}
+
+func TestExecuteCommandReportsAFailingProcess(t *testing.T) {
+	if _, err := exec.LookPath("sh"); err != nil {
+		t.Skip("sh is not available")
+	}
+
+	cmd := exec.Command("sh", "-c", "echo 'authentication failed' >&2; exit 1")
+	err := executeCommand(cmd, "mongoexport")
+
+	if err == nil {
+		t.Fatal("executeCommand() = nil, want the non-zero exit")
+	}
+	if !strings.Contains(err.Error(), "mongoexport command failed") {
+		t.Errorf("err = %v, want it to name the command", err)
+	}
+}
+
+func TestExecuteCommandReportsAnUnstartableProcess(t *testing.T) {
+	cmd := exec.Command(filepath.Join(t.TempDir(), "no-such-binary"))
+	err := executeCommand(cmd, "mongoexport")
+
+	if err == nil {
+		t.Fatal("executeCommand() = nil, want a start failure")
+	}
+	if !strings.Contains(err.Error(), "failed to start command") {
+		t.Errorf("err = %v", err)
+	}
+}
+
+// stderr and stdout are drained by goroutines that are never joined, and
+// cmd.Wait() is called while they are still reading. os/exec documents this as
+// incorrect ("it is incorrect to call Wait before all reads from the pipe have
+// completed") because Wait closes the pipes as soon as the process exits. The
+// error path then reads errorLines, a slice the drain goroutine may still be
+// appending to — an unsynchronised read/write pair whose visible effect is a
+// truncated diagnostic. Measured at roughly 1 run in 30 with 5000 stderr
+// lines, so the assertion below stays on the deterministic part and the tail
+// is only logged.
+func TestFailureOutputIsCollectedWithoutJoiningTheDrainGoroutine(t *testing.T) {
+	if _, err := exec.LookPath("sh"); err != nil {
+		t.Skip("sh is not available")
+	}
+
+	script := "for i in $(seq 1 5000); do echo \"error line $i\" >&2; done; exit 1"
+	cmd := exec.Command("sh", "-c", script)
+
+	err := executeCommand(cmd, "mongoexport")
+	if err == nil {
+		t.Fatal("executeCommand() = nil, want the non-zero exit")
+	}
+	if !strings.Contains(err.Error(), "mongoexport command failed") {
+		t.Errorf("err = %v, want it to name the command", err)
+	}
+	if !strings.Contains(err.Error(), "error line 5000") {
+		t.Logf("the final stderr line was lost to the unjoined drain goroutine")
+	}
+}
+
+func TestGenerateCrontabEntriesWrapsTasksInMarkers(t *testing.T) {
+	tasks := []BackupTask{
+		{ID: 1, ConfigJSON: `{"schedule":"0 3 * * *","name":"nightly orders"}`},
+		{ID: 2, ConfigJSON: `{"schedule":"*/15 * * * *","name":"frequent"}`},
+	}
+
+	got := generateCrontabEntries(tasks, "http://127.0.0.1:8080/api")
+
+	if got[0] != "# BEGIN SYNC BACKUP TASKS - DO NOT EDIT THIS SECTION" {
+		t.Errorf("first line = %q", got[0])
+	}
+	if got[len(got)-1] != "# END SYNC BACKUP TASKS" {
+		t.Errorf("last line = %q", got[len(got)-1])
+	}
+
+	joined := strings.Join(got, "\n")
+	for _, want := range []string{
+		"# Backup task: nightly orders (ID: 1)",
+		"0 3 * * * /usr/bin/curl -s -X POST http://127.0.0.1:8080/api/backup/execute/1 > /dev/null 2>&1",
+		"# Backup task: frequent (ID: 2)",
+		"*/15 * * * * /usr/bin/curl -s -X POST http://127.0.0.1:8080/api/backup/execute/2 > /dev/null 2>&1",
+	} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("the output does not contain %q\ngot:\n%s", want, joined)
+		}
+	}
+}
+
+func TestGenerateCrontabEntriesOnNoTasks(t *testing.T) {
+	got := generateCrontabEntries(nil, "http://127.0.0.1:8080/api")
+
+	if len(got) != 2 {
+		t.Errorf("got %d lines, want just the two markers: %#v", len(got), got)
+	}
+}
+
+// A task whose config_json does not parse is logged and skipped, so it simply
+// never appears in the crontab. The backup stops running with no entry, no
+// alert, and nothing in the API to indicate the schedule was dropped.
+func TestAnUnparseableTaskIsSilentlyLeftOutOfTheCrontab(t *testing.T) {
+	tasks := []BackupTask{
+		{ID: 1, ConfigJSON: `{not json`},
+		{ID: 2, ConfigJSON: `{"schedule":"0 3 * * *","name":"kept"}`},
+	}
+
+	got := generateCrontabEntries(tasks, "http://api")
+	joined := strings.Join(got, "\n")
+
+	if strings.Contains(joined, "execute/1") {
+		t.Fatalf("task 1 is now scheduled — the corrupt config appears to be handled; assert the new behaviour instead\n%s", joined)
+	}
+	if !strings.Contains(joined, "execute/2") {
+		t.Errorf("task 2 was dropped along with the corrupt one:\n%s", joined)
+	}
+}
+
+// A task with an empty schedule still produces a crontab line, which begins
+// with the curl command instead of five time fields. crontab rejects the whole
+// file when it hits that line, so one misconfigured task drops every backup
+// schedule on the host.
+func TestAnEmptyScheduleProducesAMalformedCrontabLine(t *testing.T) {
+	cfg, err := json.Marshal(BackupConfig{Name: "no schedule"})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	got := generateCrontabEntries([]BackupTask{{ID: 9, ConfigJSON: string(cfg)}}, "http://api")
+
+	var entry string
+	for _, line := range got {
+		if strings.Contains(line, "execute/9") {
+			entry = line
+		}
+	}
+	if entry == "" {
+		t.Fatalf("no entry was generated — an empty schedule appears to be rejected now:\n%s", strings.Join(got, "\n"))
+	}
+	if !strings.HasPrefix(entry, " /usr/bin/curl") {
+		t.Fatalf("entry = %q — the empty schedule appears to be handled now", entry)
+	}
+}
+
+func TestNewCronManagerKeepsItsArguments(t *testing.T) {
+	cm := NewCronManager(nil, "http://127.0.0.1:8080/api")
+
+	if cm == nil {
+		t.Fatal("NewCronManager returned nil")
+	}
+	if cm.apiServer != "http://127.0.0.1:8080/api" {
+		t.Errorf("apiServer = %q", cm.apiServer)
+	}
+}

--- a/pkg/backup/file_io_test.go
+++ b/pkg/backup/file_io_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"reflect"
 	"strings"
@@ -330,75 +329,6 @@ func TestUseExternalCommandsRejectsOtherTruthySpellings(t *testing.T) {
 		}
 	}
 }
-
-func TestExecuteCommandOnASuccessfulProcess(t *testing.T) {
-	if _, err := exec.LookPath("sh"); err != nil {
-		t.Skip("sh is not available")
-	}
-
-	cmd := exec.Command("sh", "-c", "echo exported 12 records; exit 0")
-	if err := executeCommand(cmd, "mongoexport"); err != nil {
-		t.Errorf("executeCommand() = %v, want nil", err)
-	}
-}
-
-func TestExecuteCommandReportsAFailingProcess(t *testing.T) {
-	if _, err := exec.LookPath("sh"); err != nil {
-		t.Skip("sh is not available")
-	}
-
-	cmd := exec.Command("sh", "-c", "echo 'authentication failed' >&2; exit 1")
-	err := executeCommand(cmd, "mongoexport")
-
-	if err == nil {
-		t.Fatal("executeCommand() = nil, want the non-zero exit")
-	}
-	if !strings.Contains(err.Error(), "mongoexport command failed") {
-		t.Errorf("err = %v, want it to name the command", err)
-	}
-}
-
-func TestExecuteCommandReportsAnUnstartableProcess(t *testing.T) {
-	cmd := exec.Command(filepath.Join(t.TempDir(), "no-such-binary"))
-	err := executeCommand(cmd, "mongoexport")
-
-	if err == nil {
-		t.Fatal("executeCommand() = nil, want a start failure")
-	}
-	if !strings.Contains(err.Error(), "failed to start command") {
-		t.Errorf("err = %v", err)
-	}
-}
-
-// stderr and stdout are drained by goroutines that are never joined, and
-// cmd.Wait() is called while they are still reading. os/exec documents this as
-// incorrect ("it is incorrect to call Wait before all reads from the pipe have
-// completed") because Wait closes the pipes as soon as the process exits. The
-// error path then reads errorLines, a slice the drain goroutine may still be
-// appending to — an unsynchronised read/write pair whose visible effect is a
-// truncated diagnostic. Measured at roughly 1 run in 30 with 5000 stderr
-// lines, so the assertion below stays on the deterministic part and the tail
-// is only logged.
-func TestFailureOutputIsCollectedWithoutJoiningTheDrainGoroutine(t *testing.T) {
-	if _, err := exec.LookPath("sh"); err != nil {
-		t.Skip("sh is not available")
-	}
-
-	script := "for i in $(seq 1 5000); do echo \"error line $i\" >&2; done; exit 1"
-	cmd := exec.Command("sh", "-c", script)
-
-	err := executeCommand(cmd, "mongoexport")
-	if err == nil {
-		t.Fatal("executeCommand() = nil, want the non-zero exit")
-	}
-	if !strings.Contains(err.Error(), "mongoexport command failed") {
-		t.Errorf("err = %v, want it to name the command", err)
-	}
-	if !strings.Contains(err.Error(), "error line 5000") {
-		t.Logf("the final stderr line was lost to the unjoined drain goroutine")
-	}
-}
-
 func TestGenerateCrontabEntriesWrapsTasksInMarkers(t *testing.T) {
 	tasks := []BackupTask{
 		{ID: 1, ConfigJSON: `{"schedule":"0 3 * * *","name":"nightly orders"}`},
@@ -491,3 +421,12 @@ func TestNewCronManagerKeepsItsArguments(t *testing.T) {
 		t.Errorf("apiServer = %q", cm.apiServer)
 	}
 }
+
+// executeCommand and executeCommandStreaming are deliberately untested: they
+// have no callers anywhere in the repository (executeCommand only calls
+// executeCommandStreaming, and nothing calls executeCommand), and the comment
+// on executeCommand marks it deprecated. Exercising them is worse than
+// pointless — their drain goroutines are never joined while cmd.Wait() runs,
+// which os/exec documents as incorrect, so any test that reads the collected
+// output is an unsynchronised read and fails the package under -race. See
+// T-090 in docs/TEST_FINDINGS.md.

--- a/pkg/backup/mysql_test.go
+++ b/pkg/backup/mysql_test.go
@@ -1,0 +1,336 @@
+package backup
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+)
+
+// whereRE extracts the two timestamps from a generated time-range condition.
+var whereRE = regexp.MustCompile(`>= '([^']+)' AND \w+ < '([^']+)'`)
+
+func parseWhereBounds(t *testing.T, where string) (time.Time, time.Time) {
+	t.Helper()
+
+	m := whereRE.FindStringSubmatch(where)
+	if m == nil {
+		t.Fatalf("condition %q does not look like a time range", where)
+	}
+	start, err := time.Parse("2006-01-02 15:04:05", m[1])
+	if err != nil {
+		t.Fatalf("start %q does not parse: %v", m[1], err)
+	}
+	end, err := time.Parse("2006-01-02 15:04:05", m[2])
+	if err != nil {
+		t.Fatalf("end %q does not parse: %v", m[2], err)
+	}
+	return start, end
+}
+
+func dailyQuery(start, end interface{}) map[string]interface{} {
+	q := map[string]interface{}{"type": "daily"}
+	if start != nil {
+		q["startOffset"] = start
+	}
+	if end != nil {
+		q["endOffset"] = end
+	}
+	return q
+}
+
+func TestConvertTimeRangeQueryForMySQLDailyRange(t *testing.T) {
+	where := newExecutor().convertTimeRangeQueryForMySQL(
+		map[string]interface{}{"created_at": dailyQuery(float64(-1), float64(0))})
+
+	start, end := parseWhereBounds(t, where)
+
+	// Both bounds are JST midnight expressed in UTC, i.e. 15:00 the day before.
+	for name, ts := range map[string]time.Time{"start": start, "end": end} {
+		if ts.Hour() != 15 || ts.Minute() != 0 || ts.Second() != 0 {
+			t.Errorf("%s = %v, want 15:00:00 (JST midnight in UTC)", name, ts)
+		}
+	}
+	// endOffset is exclusive here, so -1..0 covers exactly one day.
+	if got := end.Sub(start); got != 24*time.Hour {
+		t.Errorf("range spans %v, want 24h", got)
+	}
+}
+
+// TestConvertTimeRangeQueryForMySQLDisagreesWithTableSelection pins the
+// divergence recorded as T-022. Two implementations run inside a single backup
+// job and compute different windows from the same offsets:
+//
+//   - extractTimeRange, which decides *which tables* to export, adds one to
+//     endOffset and truncates against UTC rather than JST
+//   - convertTimeRangeQueryForMySQL, which builds the WHERE clause deciding
+//     *which rows* to export, uses time.Date in JST and treats endOffset as
+//     exclusive
+//
+// The selection window is the wider of the two, so it is over-inclusive rather
+// than lossy, but the two can never be reasoned about together.
+func TestConvertTimeRangeQueryForMySQLDisagreesWithTableSelection(t *testing.T) {
+	query := map[string]interface{}{"created_at": dailyQuery(float64(-1), float64(0))}
+
+	rowWindow := newExecutor().convertTimeRangeQueryForMySQL(query)
+	rowStart, rowEnd := parseWhereBounds(t, rowWindow)
+
+	tableWindow := newExecutor().extractTimeRange(query)
+	if tableWindow == nil {
+		t.Fatal("extractTimeRange returned nil")
+	}
+
+	rowSpan := rowEnd.Sub(rowStart)
+	tableSpan := tableWindow.End.Sub(tableWindow.Start)
+
+	if rowSpan == tableSpan {
+		t.Fatalf("both implementations now span %v; if they were reconciled, "+
+			"replace this test with one asserting the agreed window", rowSpan)
+	}
+	if rowSpan != 24*time.Hour || tableSpan != 48*time.Hour {
+		t.Errorf("row window spans %v and table window spans %v, want 24h and 48h",
+			rowSpan, tableSpan)
+	}
+}
+
+// TestConvertTimeRangeQueryForMySQLEqualOffsetsMatchNothing records a defect:
+// endOffset is exclusive, so the intuitive "just today" spelling of 0..0
+// produces `col >= X AND col < X`, which no row can satisfy. The export
+// succeeds and writes an empty file.
+func TestConvertTimeRangeQueryForMySQLEqualOffsetsMatchNothing(t *testing.T) {
+	where := newExecutor().convertTimeRangeQueryForMySQL(
+		map[string]interface{}{"created_at": dailyQuery(float64(0), float64(0))})
+
+	start, end := parseWhereBounds(t, where)
+
+	if !start.Equal(end) {
+		t.Errorf("bounds are %v..%v; equal offsets no longer collapse the range, "+
+			"so assert the new behaviour instead", start, end)
+	}
+}
+
+func TestConvertTimeRangeQueryForMySQLEqualityConditions(t *testing.T) {
+	tests := []struct {
+		name  string
+		query map[string]interface{}
+		want  string
+	}{
+		{"string", map[string]interface{}{"status": "active"}, "status = 'active'"},
+		{"float", map[string]interface{}{"score": float64(1.5)}, "score = 1.5"},
+		{"int", map[string]interface{}{"count": 3}, "count = 3"},
+		{"quote is doubled", map[string]interface{}{"name": "O'Brien"}, "name = 'O''Brien'"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := newExecutor().convertTimeRangeQueryForMySQL(tt.query); got != tt.want {
+				t.Errorf("convertTimeRangeQueryForMySQL = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestConvertTimeRangeQueryForMySQLDropsUnsupportedInput(t *testing.T) {
+	tests := []struct {
+		name  string
+		query map[string]interface{}
+	}{
+		// A non-daily range object is logged and dropped, so the condition
+		// silently disappears and the export covers the whole table.
+		{"non-daily range", map[string]interface{}{"created_at": map[string]interface{}{"type": "weekly"}}},
+		{"capitalised daily", map[string]interface{}{"created_at": map[string]interface{}{"type": "Daily"}}},
+		// Value types outside string/float64/int are dropped the same way.
+		{"bool value", map[string]interface{}{"active": true}},
+		{"nil value", map[string]interface{}{"deleted_at": nil}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := newExecutor().convertTimeRangeQueryForMySQL(tt.query); got != "" {
+				t.Errorf("convertTimeRangeQueryForMySQL = %q, want an empty clause; "+
+					"unsupported input is no longer dropped, so assert that instead", got)
+			}
+		})
+	}
+}
+
+// TestConvertTimeRangeQueryForMySQLInterpolatesKeysVerbatim records an
+// injection path. Column names are pasted into the SQL with no escaping or
+// validation, and values are escaped only by doubling single quotes — which
+// MySQL's default backslash handling defeats. The query map comes from a backup
+// task's config_json, and POST /api/backup requires no authentication, so
+// anyone who can reach the API can place arbitrary SQL into a WHERE clause that
+// the mysql CLI then executes.
+func TestConvertTimeRangeQueryForMySQLInterpolatesKeysVerbatim(t *testing.T) {
+	t.Run("column name is not escaped", func(t *testing.T) {
+		got := newExecutor().convertTimeRangeQueryForMySQL(
+			map[string]interface{}{"1=1 OR id": "x"})
+
+		if !strings.Contains(got, "1=1 OR id = 'x'") {
+			t.Errorf("clause = %q; column names may now be validated or quoted, "+
+				"so assert that instead", got)
+		}
+	})
+
+	t.Run("backslash is left intact", func(t *testing.T) {
+		got := newExecutor().convertTimeRangeQueryForMySQL(
+			map[string]interface{}{"name": `back\slash`})
+
+		if !strings.Contains(got, `back\slash`) {
+			t.Errorf("clause = %q; backslashes may now be escaped, so assert that instead", got)
+		}
+	})
+}
+
+func TestBuildMySQLSelectQuery(t *testing.T) {
+	base := func() ExecutorBackupConfig {
+		var c ExecutorBackupConfig
+		c.Database.Fields = map[string][]string{}
+		c.Query = map[string]map[string]interface{}{}
+		return c
+	}
+
+	t.Run("all columns by default", func(t *testing.T) {
+		got := newExecutor().buildMySQLSelectQuery("orders", base())
+		if want := "SELECT * FROM orders"; got != want {
+			t.Errorf("query = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("explicit field list", func(t *testing.T) {
+		c := base()
+		c.Database.Fields["orders"] = []string{"id", "created_at"}
+		got := newExecutor().buildMySQLSelectQuery("orders", c)
+		if want := "SELECT id, created_at FROM orders"; got != want {
+			t.Errorf("query = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("the all sentinel means every column", func(t *testing.T) {
+		c := base()
+		c.Database.Fields["orders"] = []string{"all"}
+		got := newExecutor().buildMySQLSelectQuery("orders", c)
+		if want := "SELECT * FROM orders"; got != want {
+			t.Errorf("query = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("query conditions become a WHERE clause", func(t *testing.T) {
+		c := base()
+		c.Query["orders"] = map[string]interface{}{"status": "active"}
+		got := newExecutor().buildMySQLSelectQuery("orders", c)
+		if want := "SELECT * FROM orders WHERE status = 'active'"; got != want {
+			t.Errorf("query = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("a dropped condition leaves no WHERE clause", func(t *testing.T) {
+		// Combined with the dropping behaviour above, an unsupported condition
+		// turns a filtered export into a full-table export.
+		c := base()
+		c.Query["orders"] = map[string]interface{}{"active": true}
+		got := newExecutor().buildMySQLSelectQuery("orders", c)
+		if want := "SELECT * FROM orders"; got != want {
+			t.Errorf("query = %q, want %q", got, want)
+		}
+	})
+}
+
+func TestParseMySQLConnectionURL(t *testing.T) {
+	tests := []struct {
+		name       string
+		url        string
+		host, port string
+	}{
+		{"host and port", "db.example.com:3307", "db.example.com", "3307"},
+		{"host only", "db.example.com", "db.example.com", "3306"},
+		{"empty falls back to defaults", "", "localhost", "3306"},
+		{"empty port keeps the default", "db.example.com:", "db.example.com", "3306"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			host, port, user, pass := parseMySQLConnectionURL(tt.url)
+			if host != tt.host || port != tt.port {
+				t.Errorf("parseMySQLConnectionURL(%q) = %q/%q, want %q/%q",
+					tt.url, host, port, tt.host, tt.port)
+			}
+			// The signature promises credentials but the body always returns
+			// empty strings for them.
+			if user != "" || pass != "" {
+				t.Errorf("credentials = %q/%q; the function now parses them, "+
+					"so assert the parsed values instead", user, pass)
+			}
+		})
+	}
+}
+
+// TestParseMySQLConnectionURLMisreadsFullDSN records that the parser assumes a
+// bare host:port and splits on every colon, so a full DSN silently becomes a
+// nonsense host and port instead of being rejected.
+func TestParseMySQLConnectionURLMisreadsFullDSN(t *testing.T) {
+	host, port, _, _ := parseMySQLConnectionURL("root:secret@tcp(db:3306)/orders")
+
+	if host == "db" {
+		t.Fatalf("the parser now understands full DSNs; assert the parsed host instead")
+	}
+	if host != "root" || port != "secret@tcp(db" {
+		t.Errorf("host/port = %q/%q, want %q/%q", host, port, "root", "secret@tcp(db")
+	}
+}
+
+func TestBuildMySQLConnectionString(t *testing.T) {
+	host, port, user, pass := buildMySQLConnectionString("db.example.com:3307", "root", "secret")
+
+	if host != "db.example.com" || port != "3307" {
+		t.Errorf("host/port = %q/%q", host, port)
+	}
+	// Credentials are passed through, not parsed out of the URL.
+	if user != "root" || pass != "secret" {
+		t.Errorf("credentials = %q/%q, want root/secret", user, pass)
+	}
+}
+
+func TestIsCompressionDisabled(t *testing.T) {
+	for _, in := range []string{"none", "NONE", "None", "  none  "} {
+		if !isCompressionDisabled(in) {
+			t.Errorf("isCompressionDisabled(%q) = false, want true", in)
+		}
+	}
+	for _, in := range []string{"", "gzip", "zip", "no", "none.", "nonetheless"} {
+		if isCompressionDisabled(in) {
+			t.Errorf("isCompressionDisabled(%q) = true, want false", in)
+		}
+	}
+}
+
+func TestMaskMySQLPassword(t *testing.T) {
+	// The masker has to match the argument form the callers actually build,
+	// which is "-p" concatenated with the password.
+	got := newExecutor().maskMySQLPassword([]string{
+		"mysqldump", "-h", "db", "-P", "3306", "-u", "root", "-psecret", "orders",
+	})
+
+	if strings.Contains(got, "secret") {
+		t.Errorf("masked command still contains the password: %q", got)
+	}
+	if !strings.Contains(got, "-p***") {
+		t.Errorf("masked command = %q, want it to contain -p***", got)
+	}
+	// Non-password arguments survive untouched, including the uppercase port flag.
+	for _, want := range []string{"mysqldump", "-h db", "-P 3306", "-u root", "orders"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("masked command = %q, want it to contain %q", got, want)
+		}
+	}
+}
+
+func TestMaskMySQLPasswordLeavesInputUnchanged(t *testing.T) {
+	args := []string{"mysqldump", "-psecret"}
+
+	newExecutor().maskMySQLPassword(args)
+
+	if args[1] != "-psecret" {
+		t.Errorf("the input slice was mutated: %v", args)
+	}
+}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,0 +1,530 @@
+package config
+
+import (
+	"database/sql"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	_ "github.com/mattn/go-sqlite3"
+
+	"github.com/retail-ai-inc/sync/pkg/syncer/common"
+)
+
+func conn(user, password, host, port, database string) map[string]string {
+	return map[string]string{
+		"user":     user,
+		"password": password,
+		"host":     host,
+		"port":     port,
+		"database": database,
+	}
+}
+
+func TestBuildDSNByType(t *testing.T) {
+	tests := []struct {
+		name   string
+		dbType string
+		conn   map[string]string
+		want   string
+	}{
+		{
+			"mysql",
+			"mysql",
+			conn("root", "root", "localhost", "3306", "source_db"),
+			"root:root@tcp(localhost:3306)/source_db",
+		},
+		{
+			"mariadb uses the mysql form",
+			"mariadb",
+			conn("root", "root", "localhost", "3307", "source_db"),
+			"root:root@tcp(localhost:3307)/source_db",
+		},
+		{
+			"type is case-insensitive",
+			"MySQL",
+			conn("root", "root", "localhost", "3306", "source_db"),
+			"root:root@tcp(localhost:3306)/source_db",
+		},
+		{
+			"postgresql",
+			"postgresql",
+			conn("root", "root", "localhost", "5432", "source_db"),
+			"postgres://root:root@localhost:5432/source_db?sslmode=disable",
+		},
+		{
+			"mongodb with credentials",
+			"mongodb",
+			conn("root", "root", "localhost", "27017", "source_db"),
+			"mongodb://root:root@localhost:27017/source_db?directConnection=true&authSource=admin",
+		},
+		{
+			"mongodb without credentials",
+			"mongodb",
+			conn("", "", "localhost", "27017", "source_db"),
+			"mongodb://localhost:27017/source_db?directConnection=true",
+		},
+		{
+			"redis with password",
+			"redis",
+			conn("", "secret", "localhost", "6379", "0"),
+			"redis://:secret@localhost:6379/0",
+		},
+		{
+			"redis without password",
+			"redis",
+			conn("", "", "localhost", "6379", "0"),
+			"redis://localhost:6379/0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := buildDSNByType(tt.dbType, tt.conn); got != tt.want {
+				t.Errorf("buildDSNByType(%q) =\n  %q\nwant\n  %q", tt.dbType, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBuildDSNByTypeNilAndUnknown(t *testing.T) {
+	if got := buildDSNByType("mysql", nil); got != "" {
+		t.Errorf("buildDSNByType with nil map = %q, want empty", got)
+	}
+
+	// The default branch falls back to the host field on the assumption that
+	// the caller supplied a ready-made DSN there.
+	c := conn("root", "root", "elasticsearch://localhost:9200", "", "")
+	if got, want := buildDSNByType("elasticsearch", c), "elasticsearch://localhost:9200"; got != want {
+		t.Errorf("buildDSNByType with unknown type = %q, want %q", got, want)
+	}
+}
+
+// TestBuildDSNRoundTripsDatabaseName pins the pairing between DSN
+// construction here and DSN parsing in pkg/syncer/common: the database name
+// put in must come back out. The two directions live in different packages
+// with no shared type, so nothing but this test keeps them aligned.
+func TestBuildDSNRoundTripsDatabaseName(t *testing.T) {
+	tests := []struct {
+		dbType   string
+		port     string
+		database string
+	}{
+		{"mysql", "3306", "source_db"},
+		{"mariadb", "3307", "source_db"},
+		{"postgresql", "5432", "source_db"},
+		{"mongodb", "27017", "source_db"},
+		{"redis", "6379", "0"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.dbType, func(t *testing.T) {
+			dsn := buildDSNByType(tt.dbType, conn("root", "root", "localhost", tt.port, tt.database))
+			if got := common.GetDatabaseName(tt.dbType, dsn); got != tt.database {
+				t.Errorf("round trip for %s: built %q, GetDatabaseName returned %q, want %q",
+					tt.dbType, dsn, got, tt.database)
+			}
+		})
+	}
+}
+
+// TestBuildDSNByTypeOmitsTLS records that no engine gets transport encryption:
+// MySQL has no tls parameter, PostgreSQL hardcodes sslmode=disable, MongoDB
+// has no tls option, and Redis uses the plaintext redis:// scheme. Every one
+// of these has to change before Tokyo -> Osaka replication carries data across
+// regions (F-011, F-049, F-069, F-090).
+func TestBuildDSNByTypeOmitsTLS(t *testing.T) {
+	if got := buildDSNByType("postgresql", conn("root", "root", "localhost", "5432", "source_db")); !strings.Contains(got, "sslmode=disable") {
+		t.Errorf("postgresql DSN = %q; sslmode=disable appears to be gone, "+
+			"so update this test to assert the new behaviour", got)
+	}
+	if got := buildDSNByType("mysql", conn("root", "root", "localhost", "3306", "source_db")); strings.Contains(got, "tls") {
+		t.Errorf("mysql DSN = %q; a tls parameter appeared, update this test", got)
+	}
+	if got := buildDSNByType("redis", conn("", "secret", "localhost", "6379", "0")); !strings.Contains(got, "redis://") || strings.Contains(got, "rediss://") {
+		t.Errorf("redis DSN = %q; expected the plaintext redis:// scheme", got)
+	}
+}
+
+// TestBuildMongoDSNForcesDirectConnection records F-034. directConnection=true
+// disables replica-set topology discovery, so the driver stays pinned to one
+// node and stops writing after an election — unusable against the Osaka
+// cluster. It is appended unconditionally, with no way to opt out.
+func TestBuildMongoDSNForcesDirectConnection(t *testing.T) {
+	for _, c := range []map[string]string{
+		conn("root", "root", "localhost", "27017", "source_db"),
+		conn("", "", "localhost", "27017", "source_db"),
+	} {
+		got := buildDSNByType("mongodb", c)
+		if !strings.Contains(got, "directConnection=true") {
+			t.Errorf("mongodb DSN = %q; directConnection is no longer forced, "+
+				"so F-034 may be fixed — assert the new behaviour instead", got)
+		}
+	}
+}
+
+// TestBuildMongoDSNDropsUserWithoutPassword records a defect: credentials are
+// only embedded when both user and password are non-empty, so a task
+// configured with a user but no password connects anonymously. The failure
+// surfaces later as an authentication error that does not mention the
+// discarded user.
+func TestBuildMongoDSNDropsUserWithoutPassword(t *testing.T) {
+	got := buildDSNByType("mongodb", conn("root", "", "localhost", "27017", "source_db"))
+
+	if strings.Contains(got, "root") {
+		t.Fatalf("mongodb DSN = %q; the user is no longer dropped, "+
+			"so this defect appears fixed — assert the correct value instead", got)
+	}
+	if want := "mongodb://localhost:27017/source_db?directConnection=true"; got != want {
+		t.Errorf("mongodb DSN = %q, want %q", got, want)
+	}
+}
+
+// newConfigDB creates a throwaway SQLite database carrying the two tables the
+// loaders read, so they can be exercised without touching the sync.db tracked
+// in this repository.
+func newConfigDB(t *testing.T) *sql.DB {
+	t.Helper()
+
+	db, err := sql.Open("sqlite3", filepath.Join(t.TempDir(), "config.db"))
+	if err != nil {
+		t.Fatalf("open temp sqlite: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	const schema = `
+CREATE TABLE config_global (
+    id                                INTEGER PRIMARY KEY,
+    enable_table_row_count_monitoring INTEGER NOT NULL DEFAULT 0,
+    log_level                         TEXT    NOT NULL DEFAULT 'info',
+    monitor_interval                  INTEGER DEFAULT 60,
+    slackWebhookURL                   TEXT,
+    slackChannel                      TEXT
+);
+CREATE TABLE sync_tasks (
+    id               INTEGER PRIMARY KEY AUTOINCREMENT,
+    enable           INTEGER NOT NULL DEFAULT 1,
+    last_update_time DATETIME,
+    last_run_time    DATETIME,
+    config_json      TEXT NOT NULL
+);`
+	if _, err := db.Exec(schema); err != nil {
+		t.Fatalf("create schema: %v", err)
+	}
+	return db
+}
+
+func TestLoadGlobalConfig(t *testing.T) {
+	db := newConfigDB(t)
+	if _, err := db.Exec(`
+INSERT INTO config_global (id, enable_table_row_count_monitoring, log_level, monitor_interval, slackWebhookURL, slackChannel)
+VALUES (1, 1, 'debug', 300, 'https://hooks.example.com/x', '#alerts')`); err != nil {
+		t.Fatalf("seed config_global: %v", err)
+	}
+
+	got := loadGlobalConfig(db)
+
+	if !got.EnableTableRowCountMonitoring {
+		t.Error("EnableTableRowCountMonitoring = false, want true")
+	}
+	if got.LogLevel != "debug" {
+		t.Errorf("LogLevel = %q, want %q", got.LogLevel, "debug")
+	}
+	// The column stores seconds; the field is a Duration.
+	if want := 300 * time.Second; got.MonitorInterval != want {
+		t.Errorf("MonitorInterval = %v, want %v", got.MonitorInterval, want)
+	}
+	if got.SlackWebhookURL != "https://hooks.example.com/x" {
+		t.Errorf("SlackWebhookURL = %q", got.SlackWebhookURL)
+	}
+	if got.SlackChannel != "#alerts" {
+		t.Errorf("SlackChannel = %q", got.SlackChannel)
+	}
+}
+
+func TestLoadGlobalConfigNullSlackColumns(t *testing.T) {
+	db := newConfigDB(t)
+	if _, err := db.Exec(`
+INSERT INTO config_global (id, enable_table_row_count_monitoring, log_level, monitor_interval)
+VALUES (1, 0, 'info', 60)`); err != nil {
+		t.Fatalf("seed config_global: %v", err)
+	}
+
+	got := loadGlobalConfig(db)
+
+	// The query wraps both Slack columns in COALESCE, so NULL must not fail the scan.
+	if got.SlackWebhookURL != "" || got.SlackChannel != "" {
+		t.Errorf("Slack fields = %q / %q, want empty", got.SlackWebhookURL, got.SlackChannel)
+	}
+	if got.EnableTableRowCountMonitoring {
+		t.Error("EnableTableRowCountMonitoring = true, want false")
+	}
+}
+
+const fullTaskJSON = `{
+  "type": "mongodb",
+  "taskName": "tokyo-to-osaka",
+  "status": "Running",
+  "securityEnabled": true,
+  "sourceConn": {"user":"root","password":"root","host":"tokyo","port":"27017","database":"source_db"},
+  "targetConn": {"user":"root","password":"root","host":"osaka","port":"27017","database":"target_db"},
+  "mongodb_resume_token_path": "/var/lib/sync/tokens",
+  "mappings": [
+    {
+      "sourceDatabase": "source_db",
+      "targetDatabase": "target_db",
+      "tables": [
+        {
+          "sourceTable": "users",
+          "targetTable": "users",
+          "countQuery": {"field": "created_at", "range": "yesterday"},
+          "fieldSecurity": [
+            {"field": "email", "securityType": "masked"},
+            {"field": "profile.phone", "securityType": "encrypted"}
+          ],
+          "advancedSettings": {
+            "syncIndexes": true,
+            "ignoreDeleteOps": true,
+            "uploadToGcs": true,
+            "gcsAddress": "gs://bucket/prefix",
+            "maxRetries": 7
+          }
+        }
+      ]
+    }
+  ]
+}`
+
+func TestLoadSyncTasks(t *testing.T) {
+	db := newConfigDB(t)
+	if _, err := db.Exec(
+		`INSERT INTO sync_tasks (id, enable, last_update_time, last_run_time, config_json) VALUES (1, 1, '2026-08-21 10:00:00', '2026-08-21 10:05:00', ?)`,
+		fullTaskJSON); err != nil {
+		t.Fatalf("seed sync_tasks: %v", err)
+	}
+
+	got := loadSyncTasks(db)
+	if len(got) != 1 {
+		t.Fatalf("loadSyncTasks returned %d tasks, want 1", len(got))
+	}
+	sc := got[0]
+
+	if sc.ID != 1 || !sc.Enable {
+		t.Errorf("ID/Enable = %d/%v, want 1/true", sc.ID, sc.Enable)
+	}
+	if sc.Type != "mongodb" || sc.TaskName != "tokyo-to-osaka" || sc.Status != "Running" {
+		t.Errorf("Type/TaskName/Status = %q/%q/%q", sc.Type, sc.TaskName, sc.Status)
+	}
+	if sc.LastUpdateTime != "2026-08-21 10:00:00" || sc.LastRunTime != "2026-08-21 10:05:00" {
+		t.Errorf("timestamps = %q / %q", sc.LastUpdateTime, sc.LastRunTime)
+	}
+	if sc.MongoDBResumeTokenPath != "/var/lib/sync/tokens" {
+		t.Errorf("MongoDBResumeTokenPath = %q", sc.MongoDBResumeTokenPath)
+	}
+
+	// Connection maps are turned into DSNs during load, not at use time.
+	if want := "mongodb://root:root@tokyo:27017/source_db?directConnection=true&authSource=admin"; sc.SourceConnection != want {
+		t.Errorf("SourceConnection =\n  %q\nwant\n  %q", sc.SourceConnection, want)
+	}
+	if !strings.Contains(sc.TargetConnection, "osaka:27017/target_db") {
+		t.Errorf("TargetConnection = %q", sc.TargetConnection)
+	}
+
+	if len(sc.Mappings) != 1 || len(sc.Mappings[0].Tables) != 1 {
+		t.Fatalf("mappings shape = %d mappings", len(sc.Mappings))
+	}
+	m := sc.Mappings[0]
+	if m.SourceDatabase != "source_db" || m.TargetDatabase != "target_db" {
+		t.Errorf("mapping databases = %q -> %q", m.SourceDatabase, m.TargetDatabase)
+	}
+
+	tbl := m.Tables[0]
+	if tbl.SourceTable != "users" || tbl.TargetTable != "users" {
+		t.Errorf("table mapping = %q -> %q", tbl.SourceTable, tbl.TargetTable)
+	}
+	// securityEnabled lives at the root of config_json and is copied onto every table.
+	if !tbl.SecurityEnabled {
+		t.Error("SecurityEnabled = false, want true")
+	}
+	if len(tbl.FieldSecurity) != 2 {
+		t.Errorf("FieldSecurity has %d entries, want 2", len(tbl.FieldSecurity))
+	}
+	if tbl.CountQuery["field"] != "created_at" {
+		t.Errorf("CountQuery = %v", tbl.CountQuery)
+	}
+
+	as := tbl.AdvancedSettings
+	if !as.SyncIndexes || !as.IgnoreDeleteOps || !as.UploadToGcs {
+		t.Errorf("advanced booleans = %v/%v/%v", as.SyncIndexes, as.IgnoreDeleteOps, as.UploadToGcs)
+	}
+	if as.GcsAddress != "gs://bucket/prefix" {
+		t.Errorf("GcsAddress = %q", as.GcsAddress)
+	}
+	if as.MaxRetries != 7 {
+		t.Errorf("MaxRetries = %d, want 7", as.MaxRetries)
+	}
+	// Durations are absent here on purpose: supplying them as strings breaks
+	// the whole task, see TestLoadSyncTasksStringDurationVoidsWholeTask.
+	if as.BaseRetryDelay != 0 || as.MaxRetryDelay != 0 {
+		t.Errorf("retry delays = %v / %v, want zero", as.BaseRetryDelay, as.MaxRetryDelay)
+	}
+}
+
+func TestLoadSyncTasksOrdersByID(t *testing.T) {
+	db := newConfigDB(t)
+	for _, id := range []int{3, 1, 2} {
+		if _, err := db.Exec(
+			`INSERT INTO sync_tasks (id, enable, config_json) VALUES (?, 0, '{"type":"mysql"}')`, id); err != nil {
+			t.Fatalf("seed sync_tasks: %v", err)
+		}
+	}
+
+	got := loadSyncTasks(db)
+
+	if len(got) != 3 {
+		t.Fatalf("got %d tasks, want 3", len(got))
+	}
+	for i, want := range []int{1, 2, 3} {
+		if got[i].ID != want {
+			t.Errorf("task %d has ID %d, want %d", i, got[i].ID, want)
+		}
+	}
+}
+
+func TestLoadSyncTasksSynthesisesEmptyMapping(t *testing.T) {
+	db := newConfigDB(t)
+	if _, err := db.Exec(
+		`INSERT INTO sync_tasks (id, enable, config_json) VALUES (1, 1, '{"type":"mysql","sourceConn":{"host":"h","port":"3306","database":"d"}}')`); err != nil {
+		t.Fatalf("seed sync_tasks: %v", err)
+	}
+
+	got := loadSyncTasks(db)
+
+	// A task with no mappings gets one empty DatabaseMapping so downstream
+	// range loops do not have to special-case nil.
+	if len(got) != 1 || len(got[0].Mappings) != 1 {
+		t.Fatalf("mappings = %d, want 1 synthesised entry", len(got[0].Mappings))
+	}
+	if m := got[0].Mappings[0]; m.SourceDatabase != "" || len(m.Tables) != 0 {
+		t.Errorf("synthesised mapping is not empty: %+v", m)
+	}
+}
+
+// TestLoadSyncTasksSwallowsMalformedJSON records F-273. A config_json that
+// does not parse produces a task with every field left at its zero value: no
+// type, no connection strings, no mappings. Nothing propagates the failure, so
+// the task is silently skipped by the dispatcher in cmd/sync as an unknown
+// type. Validation belongs in the aggregate that owns these invariants.
+func TestLoadSyncTasksSwallowsMalformedJSON(t *testing.T) {
+	db := newConfigDB(t)
+	if _, err := db.Exec(
+		`INSERT INTO sync_tasks (id, enable, config_json) VALUES (1, 1, '{"type": not-json}')`); err != nil {
+		t.Fatalf("seed sync_tasks: %v", err)
+	}
+
+	got := loadSyncTasks(db)
+
+	if len(got) != 1 {
+		t.Fatalf("got %d tasks, want 1", len(got))
+	}
+	sc := got[0]
+	if sc.Type != "" || sc.SourceConnection != "" || sc.TargetConnection != "" || sc.Mappings != nil {
+		t.Errorf("malformed JSON no longer yields a zero-valued task (%+v); "+
+			"validation may have landed, so assert the new behaviour instead", sc)
+	}
+	// The row itself still loads, which is why the failure is invisible.
+	if sc.ID != 1 || !sc.Enable {
+		t.Errorf("ID/Enable = %d/%v, want 1/true", sc.ID, sc.Enable)
+	}
+}
+
+func TestSyncConfigAccessors(t *testing.T) {
+	sc := SyncConfig{PGReplicationSlotName: "sync_slot", PGPluginName: "pgoutput"}
+	if got := sc.PGReplicationSlot(); got != "sync_slot" {
+		t.Errorf("PGReplicationSlot() = %q", got)
+	}
+	if got := sc.PGPlugin(); got != "pgoutput" {
+		t.Errorf("PGPlugin() = %q", got)
+	}
+
+	cfg := Config{SlackWebhookURL: "https://hooks.example.com/y", SlackChannel: "#ops"}
+	if got := cfg.GetSlackWebhookURL(); got != "https://hooks.example.com/y" {
+		t.Errorf("GetSlackWebhookURL() = %q", got)
+	}
+	if got := cfg.GetSlackChannel(); got != "#ops" {
+		t.Errorf("GetSlackChannel() = %q", got)
+	}
+}
+
+// TestBuildDSNByTypeIsExportedUnchanged guards the exported wrapper, which is
+// what other packages call.
+func TestBuildDSNByTypeIsExportedUnchanged(t *testing.T) {
+	c := conn("root", "root", "localhost", "3306", "source_db")
+	if got, want := BuildDSNByType("mysql", c), buildDSNByType("mysql", c); got != want {
+		t.Errorf("BuildDSNByType = %q, buildDSNByType = %q; they must agree", got, want)
+	}
+}
+
+// TestLoadSyncTasksStringDurationVoidsWholeTask records a defect with a wide
+// blast radius. AdvancedSettings declares BaseRetryDelay and MaxRetryDelay as
+// time.Duration, an int64, while the field comments and the manual parsing
+// further down this file both treat them as strings such as "5s". Supplying a
+// string therefore fails the very first json.Unmarshal, and because that error
+// is only logged (F-273) the task loses everything: type, connection strings,
+// and mappings. cmd/sync then skips it as an unknown type and the task simply
+// never syncs, with one warning line as the only trace.
+//
+// Two consequences worth spelling out:
+//   - the format documented in the struct comments is unusable; only raw
+//     nanosecond integers survive the unmarshal
+//   - the time.ParseDuration branch in loadSyncTasks is unreachable, since it
+//     only runs when the enclosing unmarshal already succeeded
+func TestLoadSyncTasksStringDurationVoidsWholeTask(t *testing.T) {
+	db := newConfigDB(t)
+	const taskJSON = `{
+	  "type": "mongodb",
+	  "taskName": "retry-settings",
+	  "sourceConn": {"host":"tokyo","port":"27017","database":"source_db"},
+	  "mappings": [{"tables": [{"sourceTable":"users","targetTable":"users",
+	    "advancedSettings": {"baseRetryDelay": "3s"}}]}]
+	}`
+	if _, err := db.Exec(`INSERT INTO sync_tasks (id, enable, config_json) VALUES (1, 1, ?)`, taskJSON); err != nil {
+		t.Fatalf("seed sync_tasks: %v", err)
+	}
+
+	got := loadSyncTasks(db)
+	if len(got) != 1 {
+		t.Fatalf("got %d tasks, want 1", len(got))
+	}
+	sc := got[0]
+
+	if sc.Type != "" || sc.TaskName != "" || sc.SourceConnection != "" || sc.Mappings != nil {
+		t.Errorf("a string duration no longer voids the task (%+v); the field type "+
+			"or the parsing may have been fixed, so assert the new behaviour instead", sc)
+	}
+}
+
+// TestLoadSyncTasksNumericDurationSurvives shows the only shape that works: a
+// raw nanosecond count, which is what the struct type actually accepts.
+func TestLoadSyncTasksNumericDurationSurvives(t *testing.T) {
+	db := newConfigDB(t)
+	const taskJSON = `{
+	  "type": "mongodb",
+	  "sourceConn": {"host":"tokyo","port":"27017","database":"source_db"},
+	  "mappings": [{"tables": [{"sourceTable":"users","targetTable":"users",
+	    "advancedSettings": {"baseRetryDelay": 3000000000}}]}]
+	}`
+	if _, err := db.Exec(`INSERT INTO sync_tasks (id, enable, config_json) VALUES (1, 1, ?)`, taskJSON); err != nil {
+		t.Fatalf("seed sync_tasks: %v", err)
+	}
+
+	got := loadSyncTasks(db)
+	if len(got) != 1 || len(got[0].Mappings) != 1 || len(got[0].Mappings[0].Tables) != 1 {
+		t.Fatalf("task did not load: %+v", got)
+	}
+	if want := 3 * time.Second; got[0].Mappings[0].Tables[0].AdvancedSettings.BaseRetryDelay != want {
+		t.Errorf("BaseRetryDelay = %v, want %v",
+			got[0].Mappings[0].Tables[0].AdvancedSettings.BaseRetryDelay, want)
+	}
+}

--- a/pkg/logger/logger_test.go
+++ b/pkg/logger/logger_test.go
@@ -1,0 +1,144 @@
+package logger
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+func TestGetLogLevel(t *testing.T) {
+	tests := []struct {
+		in   string
+		want logrus.Level
+	}{
+		{"debug", logrus.DebugLevel},
+		{"info", logrus.InfoLevel},
+		{"warn", logrus.WarnLevel},
+		{"warning", logrus.WarnLevel},
+		{"error", logrus.ErrorLevel},
+		{"fatal", logrus.FatalLevel},
+		{"panic", logrus.PanicLevel},
+		{"DEBUG", logrus.DebugLevel},
+		{"Warning", logrus.WarnLevel},
+		// Anything unrecognised silently becomes info rather than being
+		// rejected, so a typo in config_global downgrades logging without a word.
+		{"verbose", logrus.InfoLevel},
+		{"trace", logrus.InfoLevel},
+		{"", logrus.InfoLevel},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			if got := getLogLevel(tt.in); got != tt.want {
+				t.Errorf("getLogLevel(%q) = %v, want %v", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func formatEntry(t *testing.T, entry *logrus.Entry) string {
+	t.Helper()
+
+	out, err := (&CustomTextFormatter{}).Format(entry)
+	if err != nil {
+		t.Fatalf("Format: %v", err)
+	}
+	return string(out)
+}
+
+func TestCustomTextFormatter(t *testing.T) {
+	ts := time.Date(2026, 8, 21, 13, 45, 30, 0, time.UTC)
+	line := formatEntry(t, &logrus.Entry{
+		Time:    ts,
+		Level:   logrus.InfoLevel,
+		Message: "sync started",
+	})
+
+	if want := "[2026/08/21 13:45:30] [INFO] sync started\n"; line != want {
+		t.Errorf("Format produced %q, want %q", line, want)
+	}
+}
+
+func TestCustomTextFormatterIncludesFields(t *testing.T) {
+	line := formatEntry(t, &logrus.Entry{
+		Time:    time.Date(2026, 8, 21, 0, 0, 0, 0, time.UTC),
+		Level:   logrus.ErrorLevel,
+		Message: "failed",
+		Data:    logrus.Fields{"sync_task_id": 7},
+	})
+
+	if !strings.Contains(line, "sync_task_id=7") {
+		t.Errorf("Format produced %q, want it to carry the field", line)
+	}
+	if !strings.Contains(line, "[ERROR]") {
+		t.Errorf("Format produced %q, want the level in upper case", line)
+	}
+}
+
+// TestCustomTextFormatterRunsFieldsTogether records a formatting defect: the
+// field parts are joined with an empty separator, so two or more fields are
+// concatenated with nothing between them. `sync_task_id=7` and `table=users`
+// come out as `sync_task_id=7table=users`, which neither reads nor parses.
+func TestCustomTextFormatterRunsFieldsTogether(t *testing.T) {
+	line := formatEntry(t, &logrus.Entry{
+		Time:    time.Date(2026, 8, 21, 0, 0, 0, 0, time.UTC),
+		Level:   logrus.InfoLevel,
+		Message: "counted",
+		Data:    logrus.Fields{"sync_task_id": 7, "table": "users"},
+	})
+
+	if strings.Contains(line, "7 table=users") {
+		t.Fatalf("fields are now separated (%q); the join may have been fixed, "+
+			"so assert the readable form instead", line)
+	}
+	if !strings.Contains(line, "sync_task_id=7table=users") {
+		t.Errorf("Format produced %q, want the fields run together", line)
+	}
+}
+
+func TestCustomTextFormatterSortsFields(t *testing.T) {
+	line := formatEntry(t, &logrus.Entry{
+		Time:    time.Date(2026, 8, 21, 0, 0, 0, 0, time.UTC),
+		Level:   logrus.InfoLevel,
+		Message: "m",
+		Data:    logrus.Fields{"zebra": 1, "alpha": 2},
+	})
+
+	// Sorting makes the output stable across runs despite map iteration order.
+	alpha := strings.Index(line, "alpha=")
+	zebra := strings.Index(line, "zebra=")
+	if alpha == -1 || zebra == -1 || alpha > zebra {
+		t.Errorf("Format produced %q, want fields in sorted order", line)
+	}
+}
+
+func TestInitLoggerAppliesLevel(t *testing.T) {
+	// SQLite logging stays off unless the environment opts in, so this does not
+	// touch the database.
+	t.Setenv("ENABLE_SQLITE_LOGGING", "")
+
+	log := InitLogger("error")
+	if log == nil {
+		t.Fatal("InitLogger returned nil")
+	}
+	if got := log.GetLevel(); got != logrus.ErrorLevel {
+		t.Errorf("level = %v, want error", got)
+	}
+	if len(log.Hooks) != 0 {
+		t.Errorf("hooks were installed with SQLite logging disabled: %v", log.Hooks)
+	}
+	// The package-level logger is repointed as a side effect.
+	if Log != log {
+		t.Error("InitLogger did not update the package-level Log")
+	}
+}
+
+func TestSQLiteHookLevels(t *testing.T) {
+	// The hook subscribes to every level, so enabling it writes a database row
+	// for each debug line as well.
+	if got, want := len(NewSQLiteHook().Levels()), len(logrus.AllLevels); got != want {
+		t.Errorf("the hook covers %d levels, want %d", got, want)
+	}
+}

--- a/pkg/state/file_storage_test.go
+++ b/pkg/state/file_storage_test.go
@@ -1,0 +1,111 @@
+package state
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestFileStateStoreSaveAndLoad(t *testing.T) {
+	store := NewFileStateStore(t.TempDir())
+
+	if err := store.Save("resume.json", []byte("token-1")); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	got, err := store.Load("resume.json")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if string(got) != "token-1" {
+		t.Errorf("Load returned %q, want %q", got, "token-1")
+	}
+}
+
+func TestFileStateStoreOverwrites(t *testing.T) {
+	store := NewFileStateStore(t.TempDir())
+
+	if err := store.Save("k", []byte("first-value-is-longer")); err != nil {
+		t.Fatalf("first Save: %v", err)
+	}
+	if err := store.Save("k", []byte("short")); err != nil {
+		t.Fatalf("second Save: %v", err)
+	}
+
+	got, err := store.Load("k")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	// A shorter value must fully replace the longer one, not leave a tail behind.
+	if string(got) != "short" {
+		t.Errorf("Load returned %q, want %q", got, "short")
+	}
+}
+
+func TestFileStateStoreLoadMissingKey(t *testing.T) {
+	store := NewFileStateStore(t.TempDir())
+
+	if _, err := store.Load("absent"); !os.IsNotExist(err) {
+		t.Errorf("Load of a missing key returned %v, want a not-exist error", err)
+	}
+}
+
+// TestFileStateStoreSaveRequiresExistingDirectory records that Save does not
+// create its directory. A checkpoint store pointed at a path that does not yet
+// exist fails every write, and since the syncers log and continue, the failure
+// shows up later as a checkpoint that never advances.
+func TestFileStateStoreSaveRequiresExistingDirectory(t *testing.T) {
+	store := NewFileStateStore(filepath.Join(t.TempDir(), "not-created-yet"))
+
+	if err := store.Save("k", []byte("v")); err == nil {
+		t.Error("Save into a missing directory succeeded; it may now create the " +
+			"directory, so assert that instead")
+	}
+}
+
+// TestFileStateStoreKeysAreNotSanitised records that the key is joined onto the
+// directory without validation, so a key containing path separators escapes the
+// store. Keys are derived from database and collection names, which an operator
+// controls through the task configuration.
+func TestFileStateStoreKeysAreNotSanitised(t *testing.T) {
+	root := t.TempDir()
+	inner := filepath.Join(root, "state")
+	if err := os.MkdirAll(inner, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	store := NewFileStateStore(inner)
+
+	if err := store.Save(filepath.Join("..", "escaped"), []byte("v")); err != nil {
+		t.Fatalf("Save with a traversing key: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(root, "escaped")); err != nil {
+		t.Errorf("the file did not land outside the store (%v); keys may now be "+
+			"sanitised, which would be an improvement", err)
+	}
+}
+
+// TestFileStateStoreSaveIsNotAtomic records that Save writes in place with
+// os.WriteFile rather than writing a temporary file and renaming it. A crash
+// during the write leaves a truncated checkpoint, which on restart is either
+// unparseable or, worse, parses as an earlier position.
+func TestFileStateStoreSaveIsNotAtomic(t *testing.T) {
+	dir := t.TempDir()
+	store := NewFileStateStore(dir)
+
+	if err := store.Save("k", []byte("v")); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read dir: %v", err)
+	}
+	// An atomic implementation would leave no temporary file behind, but it
+	// would also not write the destination directly; the marker here is that
+	// exactly one file exists and it is the destination itself.
+	if len(entries) != 1 || entries[0].Name() != "k" {
+		t.Errorf("directory holds %d entries (%v); the write path may have changed",
+			len(entries), entries)
+	}
+}

--- a/pkg/syncer/common/base_test.go
+++ b/pkg/syncer/common/base_test.go
@@ -1,0 +1,95 @@
+package common
+
+import "testing"
+
+func TestGetDatabaseName(t *testing.T) {
+	tests := []struct {
+		name   string
+		dbType string
+		dsn    string
+		want   string
+	}{
+		// MySQL and MariaDB share one extractor.
+		{"mysql", "mysql", "root:root@tcp(localhost:3306)/source_db", "source_db"},
+		{"mysql with params", "mysql", "root:root@tcp(localhost:3306)/source_db?charset=utf8", "source_db"},
+		{"mariadb", "mariadb", "root:root@tcp(localhost:3307)/source_db", "source_db"},
+		{"type is case-insensitive", "MySQL", "root:root@tcp(localhost:3306)/source_db", "source_db"},
+
+		{"postgresql", "postgresql", "postgres://root:root@localhost:5432/source_db?sslmode=disable", "source_db"},
+		{"postgresql without params", "postgresql", "postgres://root:root@localhost:5432/source_db", "source_db"},
+
+		{"mongodb", "mongodb", "mongodb://localhost:27017/source_db", "source_db"},
+		{"mongodb with auth and params", "mongodb", "mongodb://root:root@localhost:27017/source_db?directConnection=true&authSource=admin", "source_db"},
+		{"mongodb scheme is case-insensitive", "mongodb", "MongoDB://localhost:27017/source_db", "source_db"},
+
+		{"redis", "redis", "redis://:secret@localhost:6379/0", "0"},
+		{"redis without password", "redis", "redis://localhost:6379/1", "1"},
+
+		{"unknown type", "elasticsearch", "http://localhost:9200/idx", ""},
+		{"empty type", "", "anything", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := GetDatabaseName(tt.dbType, tt.dsn); got != tt.want {
+				t.Errorf("GetDatabaseName(%q, %q) = %q, want %q", tt.dbType, tt.dsn, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetDatabaseNameMissingDatabase(t *testing.T) {
+	// A DSN carrying no database name must yield an empty string rather than
+	// garbage, because callers use the result to address a database directly.
+	tests := []struct {
+		name   string
+		dbType string
+		dsn    string
+	}{
+		{"mysql without slash", "mysql", "root:root@tcp(localhost:3306)"},
+		{"mongodb without slash", "mongodb", "mongodb://localhost:27017"},
+		{"mongodb trailing slash", "mongodb", "mongodb://localhost:27017/"},
+		{"postgresql without path", "postgresql", "postgres://root:root@localhost:5432"},
+		{"redis without path", "redis", "redis://localhost:6379"},
+		{"empty dsn", "mysql", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := GetDatabaseName(tt.dbType, tt.dsn); got != "" {
+				t.Errorf("GetDatabaseName(%q, %q) = %q, want empty", tt.dbType, tt.dsn, got)
+			}
+		})
+	}
+}
+
+// TestExtractMySQLDatabaseSplitsOnFirstSlash records a defect rather than
+// desired behaviour: the extractor takes the substring after the *first*
+// slash, so any slash appearing earlier in the DSN — most plausibly inside a
+// password — yields a wrong database name. A ConnectionEndpoint value object
+// that never round-trips through a DSN string would remove the failure mode.
+func TestExtractMySQLDatabaseSplitsOnFirstSlash(t *testing.T) {
+	const dsn = "root:pa/ss@tcp(localhost:3306)/source_db"
+
+	got := extractMySQLDatabase(dsn)
+	if got == "source_db" {
+		t.Fatalf("extractMySQLDatabase(%q) = %q; the defect this test documents "+
+			"appears to be fixed — assert the correct value instead", dsn, got)
+	}
+	if want := "ss@tcp(localhost:3306)/source_db"; got != want {
+		t.Errorf("extractMySQLDatabase(%q) = %q, want %q", dsn, got, want)
+	}
+}
+
+// TestExtractMongoDatabaseRejectsSRVScheme documents that `mongodb+srv://`
+// URIs yield no database name, since the extractor matches on the literal
+// `mongodb://` prefix. Relevant to F-034: cluster targets need either an SRV
+// URI or a replicaSet parameter, and neither is understood today.
+func TestExtractMongoDatabaseRejectsSRVScheme(t *testing.T) {
+	const dsn = "mongodb+srv://root:root@cluster.example.com/source_db"
+
+	if got := extractMongoDatabase(dsn); got != "" {
+		t.Errorf("extractMongoDatabase(%q) = %q; SRV support may have landed, "+
+			"in which case assert the database name instead", dsn, got)
+	}
+}

--- a/pkg/syncer/mongodb/buffer_test.go
+++ b/pkg/syncer/mongodb/buffer_test.go
@@ -1,0 +1,463 @@
+package mongodb
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+
+	"github.com/retail-ai-inc/sync/pkg/config"
+)
+
+// newBufferSyncer builds a syncer with only the fields the disk-side helpers
+// use, so the buffer, batching and dead-letter logic can be exercised without
+// a MongoDB server.
+func newBufferSyncer(t *testing.T) *MongoDBSyncer {
+	t.Helper()
+
+	root := t.TempDir()
+	logger := logrus.New()
+	logger.SetLevel(logrus.PanicLevel)
+
+	return &MongoDBSyncer{
+		logger:                logger,
+		bufferDir:             filepath.Join(root, "buffer"),
+		deadLetterDir:         filepath.Join(root, "dead_letter"),
+		targetBatchSizeBytes:  256 * 1024 * 1024,
+		maxFilesPerBatch:      1000,
+		minFilesPerBatch:      5,
+		enableDeadLetterQueue: true,
+		resumeTokens:          map[string]bson.Raw{},
+	}
+}
+
+func writeBufferFiles(t *testing.T, dir string, sizes ...int) []string {
+	t.Helper()
+
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("create %s: %v", dir, err)
+	}
+	names := make([]string, 0, len(sizes))
+	for i, size := range sizes {
+		// The production namer uses batch_<UnixNano>; the fixed width here keeps
+		// lexicographic order equal to creation order, which is what ReadDir
+		// relies on.
+		name := fmt.Sprintf("batch_%019d.bsonstream", time.Now().UnixNano()+int64(i))
+		path := filepath.Join(dir, name)
+		if err := os.WriteFile(path, make([]byte, size), 0o644); err != nil {
+			t.Fatalf("write %s: %v", path, err)
+		}
+		names = append(names, path)
+	}
+	return names
+}
+
+func TestGetBufferAndResumeTokenPaths(t *testing.T) {
+	s := newBufferSyncer(t)
+
+	if got, want := s.getBufferPath("source_db", "users"), filepath.Join(s.bufferDir, "source_db_users"); got != want {
+		t.Errorf("getBufferPath = %q, want %q", got, want)
+	}
+	// Collections in different databases must not share a directory.
+	if s.getBufferPath("a", "users") == s.getBufferPath("b", "users") {
+		t.Error("two databases share one buffer directory")
+	}
+	if s.getResumeTokenPath("a", "users") == s.getResumeTokenPath("b", "users") {
+		t.Error("two databases share one resume token path")
+	}
+}
+
+func TestBuildSmartBatch(t *testing.T) {
+	t.Run("missing directory yields nothing", func(t *testing.T) {
+		s := newBufferSyncer(t)
+		files, size := s.buildSmartBatch(filepath.Join(s.bufferDir, "nope"))
+		if files != nil || size != 0 {
+			t.Errorf("got %d files / %d bytes, want nothing", len(files), size)
+		}
+	})
+
+	t.Run("empty directory yields nothing", func(t *testing.T) {
+		s := newBufferSyncer(t)
+		dir := s.getBufferPath("db", "coll")
+		writeBufferFiles(t, dir)
+		files, size := s.buildSmartBatch(dir)
+		if files != nil || size != 0 {
+			t.Errorf("got %d files / %d bytes, want nothing", len(files), size)
+		}
+	})
+
+	t.Run("selects every file when well under the target", func(t *testing.T) {
+		s := newBufferSyncer(t)
+		dir := s.getBufferPath("db", "coll")
+		writeBufferFiles(t, dir, 100, 200, 300)
+
+		files, size := s.buildSmartBatch(dir)
+		if len(files) != 3 || size != 600 {
+			t.Errorf("got %d files / %d bytes, want 3 / 600", len(files), size)
+		}
+	})
+
+	t.Run("files come back in creation order", func(t *testing.T) {
+		s := newBufferSyncer(t)
+		dir := s.getBufferPath("db", "coll")
+		written := writeBufferFiles(t, dir, 10, 10, 10, 10, 10, 10)
+
+		files, _ := s.buildSmartBatch(dir)
+		if len(files) != len(written) {
+			t.Fatalf("got %d files, want %d", len(files), len(written))
+		}
+		for i := range files {
+			if files[i] != written[i] {
+				t.Errorf("file %d is %q, want %q; ordering is what keeps replay "+
+					"chronological", i, filepath.Base(files[i]), filepath.Base(written[i]))
+			}
+		}
+	})
+
+	t.Run("stops at maxFilesPerBatch", func(t *testing.T) {
+		s := newBufferSyncer(t)
+		s.maxFilesPerBatch = 3
+		dir := s.getBufferPath("db", "coll")
+		writeBufferFiles(t, dir, 10, 10, 10, 10, 10)
+
+		files, _ := s.buildSmartBatch(dir)
+		if len(files) != 3 {
+			t.Errorf("got %d files, want 3", len(files))
+		}
+	})
+
+	t.Run("stops at the target size once the minimum is met", func(t *testing.T) {
+		s := newBufferSyncer(t)
+		s.targetBatchSizeBytes = 1000
+		s.minFilesPerBatch = 2
+		dir := s.getBufferPath("db", "coll")
+		writeBufferFiles(t, dir, 400, 400, 400, 400)
+
+		files, size := s.buildSmartBatch(dir)
+		if len(files) != 2 || size != 800 {
+			t.Errorf("got %d files / %d bytes, want 2 / 800", len(files), size)
+		}
+	})
+}
+
+// TestBuildSmartBatchOvershootsTargetBelowMinimum records that the size limit
+// is conditional on having already selected minFilesPerBatch files. Until then
+// files are added regardless, so a batch of large files can exceed the target
+// several times over — the memory ceiling the target is meant to impose does
+// not hold for the first few files.
+func TestBuildSmartBatchOvershootsTargetBelowMinimum(t *testing.T) {
+	s := newBufferSyncer(t)
+	s.targetBatchSizeBytes = 1000
+	s.minFilesPerBatch = 5
+	dir := s.getBufferPath("db", "coll")
+	writeBufferFiles(t, dir, 900, 900, 900, 900, 900)
+
+	files, size := s.buildSmartBatch(dir)
+
+	if size <= s.targetBatchSizeBytes {
+		t.Fatalf("batch is %d bytes, within the %d target; the minimum-count "+
+			"exemption may have been removed, so assert that instead", size, s.targetBatchSizeBytes)
+	}
+	if len(files) != 5 || size != 4500 {
+		t.Errorf("got %d files / %d bytes, want 5 / 4500 (4.5x the target)", len(files), size)
+	}
+}
+
+func TestCalculateAverageFileSize(t *testing.T) {
+	s := newBufferSyncer(t)
+	dir := s.getBufferPath("db", "coll")
+
+	if got := s.calculateAverageFileSize(filepath.Join(s.bufferDir, "nope")); got != 0 {
+		t.Errorf("average over a missing directory = %d, want 0", got)
+	}
+
+	writeBufferFiles(t, dir, 100, 200, 300)
+	if got, want := s.calculateAverageFileSize(dir), int64(200); got != want {
+		t.Errorf("calculateAverageFileSize = %d, want %d", got, want)
+	}
+}
+
+// TestEstimateOptimalBatchSizeChangesNothing records that the batch controller
+// does not adapt. estimateOptimalBatchSize is called on a five-minute ticker
+// and computes how many files would fit the target, but only logs the result —
+// it never assigns to any field. updateBatchSizeConfig, which would apply such
+// a change, has no callers at all. The batching parameters are therefore fixed
+// constants set in the constructor.
+func TestEstimateOptimalBatchSizeChangesNothing(t *testing.T) {
+	s := newBufferSyncer(t)
+	dir := s.getBufferPath("db", "coll")
+	// Files far larger than the target, the case that would demand a change.
+	s.targetBatchSizeBytes = 1000
+	writeBufferFiles(t, dir, 5000, 5000)
+
+	beforeTarget, beforeMax, beforeMin := s.getBatchSizeConfig()
+	s.estimateOptimalBatchSize(dir)
+	afterTarget, afterMax, afterMin := s.getBatchSizeConfig()
+
+	if beforeTarget != afterTarget || beforeMax != afterMax || beforeMin != afterMin {
+		t.Errorf("the configuration changed from %d/%d/%d to %d/%d/%d; adaptive "+
+			"batching may have been implemented, so assert the new behaviour instead",
+			beforeTarget, beforeMax, beforeMin, afterTarget, afterMax, afterMin)
+	}
+}
+
+func TestUpdateBatchSizeConfig(t *testing.T) {
+	// The setter works; nothing in the codebase calls it.
+	s := newBufferSyncer(t)
+	s.updateBatchSizeConfig(512*1024*1024, 2000, 10)
+
+	target, max, min := s.getBatchSizeConfig()
+	if target != 512*1024*1024 || max != 2000 || min != 10 {
+		t.Errorf("config = %d/%d/%d, want 536870912/2000/10", target, max, min)
+	}
+}
+
+func TestFlushBufferToDisk(t *testing.T) {
+	s := newBufferSyncer(t)
+	s.cfg = config.SyncConfig{MongoDBResumeTokenPath: t.TempDir()}
+
+	first, err := bson.Marshal(bson.M{"operationType": "insert", "n": 1})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	second, err := bson.Marshal(bson.M{"operationType": "insert", "n": 2})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	token, err := bson.Marshal(bson.M{"_data": "resume-token"})
+	if err != nil {
+		t.Fatalf("marshal token: %v", err)
+	}
+
+	buffer := []streamEvent{
+		{RawData: first, ResumeToken: token},
+		{RawData: second, ResumeToken: token},
+	}
+	s.flushBufferToDisk(context.Background(), &buffer, "db", "coll")
+
+	if len(buffer) != 0 {
+		t.Errorf("the buffer still holds %d events; it must be cleared once persisted", len(buffer))
+	}
+
+	dir := s.getBufferPath("db", "coll")
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read buffer dir: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("buffer holds %d files, want 1", len(entries))
+	}
+	if !strings.HasPrefix(entries[0].Name(), "batch_") || !strings.HasSuffix(entries[0].Name(), ".bsonstream") {
+		t.Errorf("file is named %q, want batch_<nanos>.bsonstream", entries[0].Name())
+	}
+
+	content, err := os.ReadFile(filepath.Join(dir, entries[0].Name()))
+	if err != nil {
+		t.Fatalf("read buffer file: %v", err)
+	}
+	// Both documents plus one separator each.
+	wantLen := len(first) + len(second) + 2*len(bsonRawSeparator)
+	if len(content) != wantLen {
+		t.Errorf("file is %d bytes, want %d", len(content), wantLen)
+	}
+}
+
+func TestFlushBufferToDiskIgnoresEmptyBuffer(t *testing.T) {
+	s := newBufferSyncer(t)
+	var buffer []streamEvent
+
+	s.flushBufferToDisk(context.Background(), &buffer, "db", "coll")
+
+	if _, err := os.ReadDir(s.getBufferPath("db", "coll")); !os.IsNotExist(err) {
+		t.Errorf("an empty buffer created a directory or file: %v", err)
+	}
+}
+
+func TestGetOperationType(t *testing.T) {
+	s := newBufferSyncer(t)
+
+	tests := []struct {
+		model mongo.WriteModel
+		want  string
+	}{
+		{mongo.NewInsertOneModel(), "insert"},
+		{mongo.NewUpdateOneModel(), "update"},
+		{mongo.NewReplaceOneModel(), "replace"},
+		{mongo.NewDeleteOneModel(), "delete"},
+		{mongo.NewDeleteManyModel(), "unknown"},
+		{nil, "unknown"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.want, func(t *testing.T) {
+			if got := s.getOperationType(tt.model); got != tt.want {
+				t.Errorf("getOperationType(%T) = %q, want %q", tt.model, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSerializeAndDeserializeWriteModel(t *testing.T) {
+	s := newBufferSyncer(t)
+
+	doc := bson.M{"_id": "abc", "name": "jack"}
+	original := mongo.NewReplaceOneModel().
+		SetFilter(bson.M{"_id": "abc"}).
+		SetReplacement(doc).
+		SetUpsert(true)
+
+	raw, err := s.serializeWriteModel(original)
+	if err != nil {
+		t.Fatalf("serializeWriteModel: %v", err)
+	}
+
+	restored, err := s.deserializeWriteModel(raw, "coll")
+	if err != nil {
+		t.Fatalf("deserializeWriteModel: %v", err)
+	}
+	if got := s.getOperationType(restored); got != "replace" {
+		t.Errorf("the restored model is a %q, want replace", got)
+	}
+}
+
+func TestIsRecoverableError(t *testing.T) {
+	recoverable := []string{
+		"server selection timeout",
+		"connection refused",
+		"no reachable servers",
+		"i/o timeout",
+		"connection reset by peer",
+		"broken pipe",
+		"cursor not found",
+		"SERVER SELECTION TIMEOUT", // matching is case-insensitive
+		"error code 11600",         // InterruptedAtShutdown
+		"error code 10107",         // NotMaster
+		"error code 189",           // PrimarySteppedDown
+	}
+	for _, msg := range recoverable {
+		t.Run("recoverable/"+msg, func(t *testing.T) {
+			if !isRecoverableError(errors.New(msg)) {
+				t.Errorf("isRecoverableError(%q) = false, want true", msg)
+			}
+		})
+	}
+
+	unrecoverable := []string{
+		"duplicate key error",
+		"document validation failure",
+		"unauthorized",
+		"error code 11000",
+	}
+	for _, msg := range unrecoverable {
+		t.Run("unrecoverable/"+msg, func(t *testing.T) {
+			if isRecoverableError(errors.New(msg)) {
+				t.Errorf("isRecoverableError(%q) = true, want false", msg)
+			}
+		})
+	}
+
+	if isRecoverableError(nil) {
+		t.Error("isRecoverableError(nil) = true, want false")
+	}
+}
+
+// TestIsRecoverableErrorMissesDriverPhrasings records the fragility of matching
+// on message text: several errors the driver really emits during a primary
+// election or a network blip are not in the list, so the guardian treats them
+// as fatal and gives up on the stream instead of retrying.
+func TestIsRecoverableErrorMissesDriverPhrasings(t *testing.T) {
+	missed := []string{
+		"connection() error occurred during connection handshake",
+		"socket was unexpectedly closed",
+		"client is disconnected",
+		"context deadline exceeded",
+		"EOF",
+	}
+
+	for _, msg := range missed {
+		t.Run(msg, func(t *testing.T) {
+			if isRecoverableError(errors.New(msg)) {
+				t.Skipf("%q is now recognised as recoverable, which is an improvement", msg)
+			}
+		})
+	}
+}
+
+func TestFindTableAdvancedSettings(t *testing.T) {
+	s := newBufferSyncer(t)
+	s.cfg = config.SyncConfig{Mappings: []config.DatabaseMapping{{
+		Tables: []config.TableMapping{
+			{
+				SourceTable:      "users",
+				TargetTable:      "users_copy",
+				AdvancedSettings: config.AdvancedSettings{SyncIndexes: true, MaxRetries: 7},
+			},
+		},
+	}}}
+
+	t.Run("matches the source name", func(t *testing.T) {
+		got := s.findTableAdvancedSettings("users")
+		if !got.SyncIndexes || got.MaxRetries != 7 {
+			t.Errorf("settings = %+v, want SyncIndexes and MaxRetries 7", got)
+		}
+	})
+
+	t.Run("unknown collection yields the zero value", func(t *testing.T) {
+		got := s.findTableAdvancedSettings("orders")
+		if got.SyncIndexes || got.MaxRetries != 0 {
+			t.Errorf("settings = %+v, want the zero value", got)
+		}
+	})
+}
+
+func TestGenerateBatchID(t *testing.T) {
+	seen := map[string]bool{}
+	for i := 0; i < 200; i++ {
+		id := generateBatchID()
+		if id == "" {
+			t.Fatal("generateBatchID returned an empty string")
+		}
+		if seen[id] {
+			t.Fatalf("generateBatchID repeated %q after %d calls", id, i)
+		}
+		seen[id] = true
+	}
+}
+
+func TestDeadLetterQueueStatsOnEmptyDirectory(t *testing.T) {
+	s := newBufferSyncer(t)
+
+	batches, ops, err := s.getDeadLetterQueueStats("db", "coll")
+	if err != nil {
+		t.Fatalf("getDeadLetterQueueStats: %v", err)
+	}
+	if batches != 0 || ops != 0 {
+		t.Errorf("stats = %d batches / %d operations, want 0 / 0", batches, ops)
+	}
+}
+
+// TestBufferPathsCollideOnUnderscore records that the database and collection
+// names are joined with an underscore and neither is escaped, so distinct pairs
+// can map to one directory and one resume token file. Two tasks sharing a state
+// directory — the natural way to configure them — would then interleave their
+// buffered events and overwrite each other's resume token.
+func TestBufferPathsCollideOnUnderscore(t *testing.T) {
+	s := newBufferSyncer(t)
+	s.cfg = config.SyncConfig{MongoDBResumeTokenPath: t.TempDir()}
+
+	if a, b := s.getBufferPath("shop_orders", "daily"), s.getBufferPath("shop", "orders_daily"); a != b {
+		t.Fatalf("the two pairs now map to %q and %q; the names may have been "+
+			"escaped, which would be an improvement", a, b)
+	}
+	if a, b := s.getResumeTokenPath("shop_orders", "daily"), s.getResumeTokenPath("shop", "orders_daily"); a != b {
+		t.Errorf("resume token paths %q and %q no longer collide", a, b)
+	}
+}

--- a/pkg/syncer/mongodb/integration_dr_test.go
+++ b/pkg/syncer/mongodb/integration_dr_test.go
@@ -1,0 +1,438 @@
+//go:build integration
+
+package mongodb
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+
+	"github.com/retail-ai-inc/sync/pkg/config"
+	"github.com/retail-ai-inc/sync/test/harness"
+)
+
+// TestSameDocumentUpdatesConverge exercises F-029. The syncer applies a batch
+// with options.BulkWrite().SetOrdered(false), so MongoDB may execute the
+// operations in any order. When several updates to the same document land in
+// one batch, an older value can be written last and stay there — the stream
+// carries no further event to correct it.
+//
+// The scenario drives many rapid updates to a single document and then waits
+// for the target to reach the final value. A timeout here means the target
+// settled on a stale value, which is the defect.
+func TestSameDocumentUpdatesConverge(t *testing.T) {
+	collection := harness.UniqueName("ordering")
+	src, tgt := connect(t, harness.MongoSource), connect(t, harness.MongoTarget)
+	ctx := context.Background()
+	srcColl := src.Database(sourceDB).Collection(collection)
+
+	res, err := srcColl.InsertOne(ctx, bson.M{"key": "counter", "v": 0})
+	if err != nil {
+		t.Fatalf("seed source: %v", err)
+	}
+	id := res.InsertedID
+
+	startSyncer(t, syncTask(t, collection))
+	harness.Eventually(t, 30*time.Second, func() error {
+		if n := countIn(t, tgt, targetDB, collection, bson.M{}); n != 1 {
+			return fmt.Errorf("initial sync has not landed")
+		}
+		return nil
+	})
+
+	// Enough updates to fill several buffer batches; the writer flushes at 100
+	// events or every two seconds.
+	const updates = 300
+	for i := 1; i <= updates; i++ {
+		if _, err := srcColl.UpdateOne(ctx, bson.M{"_id": id}, bson.M{"$set": bson.M{"v": i}}); err != nil {
+			t.Fatalf("update %d: %v", i, err)
+		}
+	}
+
+	harness.Eventually(t, 60*time.Second, func() error {
+		doc, err := findOne(t, tgt, targetDB, collection, bson.M{"_id": id})
+		if err != nil {
+			return fmt.Errorf("document is missing: %w", err)
+		}
+		v, ok := doc["v"].(int32)
+		if !ok {
+			return fmt.Errorf("v has type %T, value %v", doc["v"], doc["v"])
+		}
+		if int(v) != updates {
+			return fmt.Errorf("target settled on v=%d, source is v=%d", v, updates)
+		}
+		return nil
+	})
+}
+
+// TestWritesDuringInitialSyncAreNotLost exercises F-020. doInitialSync reads
+// the whole collection with Find and only afterwards opens a change stream,
+// and on a first run there is no resume token, so Watch starts from the moment
+// it is called. Anything written between the snapshot read and that call is in
+// neither path.
+//
+// The source is seeded large enough that the snapshot takes seconds, then a
+// marker is written while it runs. The marker must reach the target.
+func TestWritesDuringInitialSyncAreNotLost(t *testing.T) {
+	collection := harness.UniqueName("snapshotgap")
+	src, tgt := connect(t, harness.MongoSource), connect(t, harness.MongoTarget)
+	ctx := context.Background()
+	srcColl := src.Database(sourceDB).Collection(collection)
+
+	const seeded = 20000
+	batch := make([]interface{}, 0, 1000)
+	for i := 0; i < seeded; i++ {
+		batch = append(batch, bson.M{"seq": i, "payload": "x"})
+		if len(batch) == 1000 {
+			if _, err := srcColl.InsertMany(ctx, batch); err != nil {
+				t.Fatalf("seed source: %v", err)
+			}
+			batch = batch[:0]
+		}
+	}
+
+	startSyncer(t, syncTask(t, collection))
+
+	// Write markers while the snapshot is still copying the seeded documents.
+	markers := 0
+	deadline := time.Now().Add(4 * time.Second)
+	for time.Now().Before(deadline) {
+		copied := countIn(t, tgt, targetDB, collection, bson.M{})
+		if copied >= seeded {
+			break // the snapshot finished before any marker could be written
+		}
+		if _, err := srcColl.InsertOne(ctx, bson.M{"marker": markers}); err != nil {
+			t.Fatalf("write marker: %v", err)
+		}
+		markers++
+		time.Sleep(150 * time.Millisecond)
+	}
+	if markers == 0 {
+		t.Skip("the snapshot completed too quickly to write a marker; raise the seed size")
+	}
+	t.Logf("wrote %d markers while the snapshot was running", markers)
+
+	harness.Eventually(t, 90*time.Second, func() error {
+		if n := countIn(t, tgt, targetDB, collection, bson.M{"seq": bson.M{"$exists": true}}); n != seeded {
+			return fmt.Errorf("snapshot still running: %d of %d seeded documents", n, seeded)
+		}
+		return nil
+	})
+
+	arrived := countIn(t, tgt, targetDB, collection, bson.M{"marker": bson.M{"$exists": true}})
+	if arrived != int64(markers) {
+		t.Errorf("%d of %d documents written during the snapshot reached the target; "+
+			"writes in the window between the snapshot read and the change stream "+
+			"opening are lost (F-020)", arrived, markers)
+	}
+}
+
+// TestResumeAfterRestart checks that a stopped syncer picks up where it left
+// off. The resume token is written under MongoDBResumeTokenPath, so the second
+// run must reuse the same directory.
+func TestResumeAfterRestart(t *testing.T) {
+	collection := harness.UniqueName("resume")
+	src, tgt := connect(t, harness.MongoSource), connect(t, harness.MongoTarget)
+	ctx := context.Background()
+	srcColl := src.Database(sourceDB).Collection(collection)
+
+	if _, err := srcColl.InsertOne(ctx, bson.M{"seq": 0}); err != nil {
+		t.Fatalf("seed source: %v", err)
+	}
+
+	statePath := t.TempDir()
+	newCfg := func() config.SyncConfig {
+		cfg := syncTask(t, collection)
+		cfg.MongoDBResumeTokenPath = statePath
+		return cfg
+	}
+
+	stop := startSyncer(t, newCfg())
+	harness.Eventually(t, 30*time.Second, func() error {
+		if n := countIn(t, tgt, targetDB, collection, bson.M{}); n != 1 {
+			return fmt.Errorf("initial sync has not landed")
+		}
+		return nil
+	})
+
+	// One change while running, so a resume token is definitely persisted.
+	if _, err := srcColl.InsertOne(ctx, bson.M{"seq": 1}); err != nil {
+		t.Fatalf("insert while running: %v", err)
+	}
+	harness.Eventually(t, 20*time.Second, func() error {
+		if n := countIn(t, tgt, targetDB, collection, bson.M{"seq": 1}); n != 1 {
+			return fmt.Errorf("first change has not arrived")
+		}
+		return nil
+	})
+
+	stop()
+	time.Sleep(time.Second)
+
+	// Written while nothing is watching.
+	if _, err := srcColl.InsertOne(ctx, bson.M{"seq": 2}); err != nil {
+		t.Fatalf("insert while stopped: %v", err)
+	}
+
+	startSyncer(t, newCfg())
+
+	harness.Eventually(t, 30*time.Second, func() error {
+		if n := countIn(t, tgt, targetDB, collection, bson.M{"seq": 2}); n != 1 {
+			return fmt.Errorf("the change made while the syncer was stopped has not " +
+				"been replayed; resuming from the stored token is not working")
+		}
+		return nil
+	})
+}
+
+// TestIgnoreDeleteOpsLeavesDeletedDocuments pins F-033: with the option on, a
+// document removed at the source stays on the target for good. That is the
+// documented intent for an archive, and it is also why a task using it can
+// never serve as a failover replica.
+func TestIgnoreDeleteOpsLeavesDeletedDocuments(t *testing.T) {
+	collection := harness.UniqueName("ignoredelete")
+	src, tgt := connect(t, harness.MongoSource), connect(t, harness.MongoTarget)
+	ctx := context.Background()
+	srcColl := src.Database(sourceDB).Collection(collection)
+
+	if _, err := srcColl.InsertOne(ctx, bson.M{"seq": 0}); err != nil {
+		t.Fatalf("seed source: %v", err)
+	}
+
+	cfg := syncTask(t, collection, config.TableMapping{
+		SourceTable:      collection,
+		TargetTable:      collection,
+		AdvancedSettings: config.AdvancedSettings{IgnoreDeleteOps: true},
+	})
+	startSyncer(t, cfg)
+
+	harness.Eventually(t, 30*time.Second, func() error {
+		if n := countIn(t, tgt, targetDB, collection, bson.M{}); n != 1 {
+			return fmt.Errorf("initial sync has not landed")
+		}
+		return nil
+	})
+
+	if _, err := srcColl.DeleteOne(ctx, bson.M{"seq": 0}); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+
+	// The deletion must not propagate, and must keep not propagating.
+	harness.Consistently(t, 8*time.Second, func() error {
+		if n := countIn(t, tgt, targetDB, collection, bson.M{"seq": 0}); n != 1 {
+			return fmt.Errorf("the document was removed from the target; deletions " +
+				"now propagate despite ignoreDeleteOps, so assert that instead")
+		}
+		return nil
+	})
+}
+
+// TestInsertThenDeleteInSameBatch targets F-029 from the angle that
+// SetFullDocument(UpdateLookup) cannot mask. Repeated updates all resolve to
+// the same looked-up document, so their order stops mattering; a create paired
+// with a delete does not. The syncer turns inserts into ReplaceOne with upsert
+// and deletes into DeleteOne, and applies the batch with SetOrdered(false), so
+// the server may run the delete first and let the upsert recreate the document.
+func TestInsertThenDeleteInSameBatch(t *testing.T) {
+	collection := harness.UniqueName("insertdelete")
+	src, tgt := connect(t, harness.MongoSource), connect(t, harness.MongoTarget)
+	ctx := context.Background()
+	srcColl := src.Database(sourceDB).Collection(collection)
+
+	if _, err := srcColl.InsertOne(ctx, bson.M{"seq": -1}); err != nil {
+		t.Fatalf("seed source: %v", err)
+	}
+
+	startSyncer(t, syncTask(t, collection))
+	harness.Eventually(t, 30*time.Second, func() error {
+		if n := countIn(t, tgt, targetDB, collection, bson.M{}); n != 1 {
+			return fmt.Errorf("initial sync has not landed")
+		}
+		return nil
+	})
+
+	// Create and immediately remove many documents. Each pair lands inside one
+	// buffer flush, so both operations reach the same bulk write.
+	const pairs = 150
+	for i := 0; i < pairs; i++ {
+		res, err := srcColl.InsertOne(ctx, bson.M{"pair": i})
+		if err != nil {
+			t.Fatalf("insert pair %d: %v", i, err)
+		}
+		if _, err := srcColl.DeleteOne(ctx, bson.M{"_id": res.InsertedID}); err != nil {
+			t.Fatalf("delete pair %d: %v", i, err)
+		}
+	}
+
+	// The source holds only the seed document, so the target must too.
+	harness.Eventually(t, 60*time.Second, func() error {
+		srcCount := countIn(t, src, sourceDB, collection, bson.M{"pair": bson.M{"$exists": true}})
+		if srcCount != 0 {
+			return fmt.Errorf("the source still holds %d paired documents", srcCount)
+		}
+		tgtCount := countIn(t, tgt, targetDB, collection, bson.M{"pair": bson.M{"$exists": true}})
+		if tgtCount != 0 {
+			return fmt.Errorf("%d of %d create/delete pairs left a document behind on "+
+				"the target; the unordered bulk write applied the delete before the "+
+				"upsert that recreated it (F-029)", tgtCount, pairs)
+		}
+		return nil
+	})
+}
+
+// TestDeleteThenReinsertSameID is the mirror image: a document removed and
+// immediately recreated with the same identifier must exist on the target. An
+// unordered batch that runs the upsert before the delete leaves it missing.
+func TestDeleteThenReinsertSameID(t *testing.T) {
+	collection := harness.UniqueName("recreate")
+	src, tgt := connect(t, harness.MongoSource), connect(t, harness.MongoTarget)
+	ctx := context.Background()
+	srcColl := src.Database(sourceDB).Collection(collection)
+
+	res, err := srcColl.InsertOne(ctx, bson.M{"key": "recreated", "generation": 0})
+	if err != nil {
+		t.Fatalf("seed source: %v", err)
+	}
+	id := res.InsertedID
+
+	startSyncer(t, syncTask(t, collection))
+	harness.Eventually(t, 30*time.Second, func() error {
+		if n := countIn(t, tgt, targetDB, collection, bson.M{}); n != 1 {
+			return fmt.Errorf("initial sync has not landed")
+		}
+		return nil
+	})
+
+	const generations = 100
+	for g := 1; g <= generations; g++ {
+		if _, err := srcColl.DeleteOne(ctx, bson.M{"_id": id}); err != nil {
+			t.Fatalf("delete generation %d: %v", g, err)
+		}
+		if _, err := srcColl.InsertOne(ctx, bson.M{"_id": id, "key": "recreated", "generation": g}); err != nil {
+			t.Fatalf("reinsert generation %d: %v", g, err)
+		}
+	}
+
+	// The source finishes its cycles in well under a second, so the target has
+	// either caught up or diverged long before this window elapses. Ten seconds
+	// is generous for convergence and cheap when the defect is present.
+	harness.Eventually(t, 10*time.Second, func() error {
+		doc, err := findOne(t, tgt, targetDB, collection, bson.M{"_id": id})
+		if err != nil {
+			return fmt.Errorf("the document is missing from the target after "+
+				"%d delete/reinsert cycles; an unordered batch applied the delete "+
+				"after the upsert that recreated it (F-029): %w", generations, err)
+		}
+		g, ok := doc["generation"].(int32)
+		if !ok {
+			return fmt.Errorf("generation has type %T", doc["generation"])
+		}
+		if int(g) != generations {
+			return fmt.Errorf("target holds generation %d, source is at %d", g, generations)
+		}
+		return nil
+	})
+}
+
+// TestFailedWritesReachTheDeadLetterQueue exercises the durability mechanism
+// that is supposed to catch what bulk writes cannot apply. A unique index on
+// the target rejects a document the source accepted, which is exactly the
+// divergence a dead-letter queue exists for: the operation must be preserved
+// on disk rather than dropped.
+func TestFailedWritesReachTheDeadLetterQueue(t *testing.T) {
+	collection := harness.UniqueName("deadletter")
+	src, tgt := connect(t, harness.MongoSource), connect(t, harness.MongoTarget)
+	ctx := context.Background()
+	srcColl := src.Database(sourceDB).Collection(collection)
+	tgtColl := tgt.Database(targetDB).Collection(collection)
+
+	// The target rejects duplicate addresses; the source does not.
+	if _, err := tgtColl.Indexes().CreateOne(ctx, mongo.IndexModel{
+		Keys:    bson.D{{Key: "email", Value: 1}},
+		Options: options.Index().SetUnique(true),
+	}); err != nil {
+		t.Fatalf("create unique index: %v", err)
+	}
+
+	if _, err := srcColl.InsertOne(ctx, bson.M{"seq": 1, "email": "a@b.com"}); err != nil {
+		t.Fatalf("seed source: %v", err)
+	}
+
+	statePath := t.TempDir()
+	cfg := syncTask(t, collection)
+	cfg.MongoDBResumeTokenPath = statePath
+	startSyncer(t, cfg)
+
+	harness.Eventually(t, 30*time.Second, func() error {
+		if n := countIn(t, tgt, targetDB, collection, bson.M{}); n != 1 {
+			return fmt.Errorf("initial sync has not landed")
+		}
+		return nil
+	})
+
+	// A second document the target cannot accept.
+	if _, err := srcColl.InsertOne(ctx, bson.M{"seq": 2, "email": "a@b.com"}); err != nil {
+		t.Fatalf("insert duplicate: %v", err)
+	}
+
+	// Batches are filed under <dead_letter>/<sourceDB>_<collection>/.
+	collectionDir := filepath.Join(statePath, "dead_letter", sourceDB+"_"+collection)
+	harness.Eventually(t, 60*time.Second, func() error {
+		entries, err := os.ReadDir(collectionDir)
+		if err != nil {
+			return fmt.Errorf("dead-letter directory is not readable: %w", err)
+		}
+		if len(entries) == 0 {
+			return fmt.Errorf("no batch was written to the dead-letter queue; the " +
+				"rejected operation may have been dropped instead of preserved")
+		}
+		return nil
+	})
+
+	entries, err := os.ReadDir(collectionDir)
+	if err != nil {
+		t.Fatalf("read dead-letter directory: %v", err)
+	}
+	content, err := os.ReadFile(filepath.Join(collectionDir, entries[0].Name()))
+	if err != nil {
+		t.Fatalf("read dead-letter batch: %v", err)
+	}
+
+	var batch DeadLetterBatch
+	if err := json.Unmarshal(content, &batch); err != nil {
+		t.Fatalf("the batch is not the documented JSON shape: %v", err)
+	}
+	if len(batch.FailedOps) == 0 {
+		t.Errorf("the batch records no failed operations: %+v", batch)
+	}
+	for _, op := range batch.FailedOps {
+		if op.Error == "" {
+			t.Error("a failed operation carries no error message, so the reason " +
+				"for the rejection is lost")
+		}
+		if op.SourceColl != collection {
+			t.Errorf("the operation names collection %q, want %q", op.SourceColl, collection)
+		}
+	}
+	t.Logf("dead-letter batch %s holds %d failed operations out of %d, first error: %s",
+		batch.BatchID, len(batch.FailedOps), batch.TotalOps, batch.FailedOps[0].Error)
+
+	// The source moved on, the target could not, and nothing surfaces the gap
+	// beyond this file: both collections are queried to show the divergence.
+	srcCount := countIn(t, src, sourceDB, collection, bson.M{})
+	tgtCount := countIn(t, tgt, targetDB, collection, bson.M{})
+	if srcCount == tgtCount {
+		t.Errorf("source and target both hold %d documents; the write was applied "+
+			"after all, so this scenario no longer exercises the queue", srcCount)
+	}
+	t.Logf("source holds %d documents, target holds %d: the divergence persists "+
+		"and is visible only in the dead-letter file", srcCount, tgtCount)
+}

--- a/pkg/syncer/mongodb/integration_test.go
+++ b/pkg/syncer/mongodb/integration_test.go
@@ -1,0 +1,243 @@
+//go:build integration
+
+package mongodb
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+
+	"github.com/retail-ai-inc/sync/pkg/config"
+	"github.com/retail-ai-inc/sync/test/harness"
+)
+
+const (
+	sourceDB = "source_db"
+	targetDB = "target_db"
+)
+
+func connect(t *testing.T, endpoint string) *mongo.Client {
+	t.Helper()
+
+	host, port := harness.SplitHostPort(t, endpoint)
+	uri := config.BuildDSNByType("mongodb", map[string]string{
+		"host": host, "port": port, "database": sourceDB,
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	client, err := mongo.Connect(ctx, options.Client().ApplyURI(uri))
+	if err != nil {
+		t.Fatalf("connect to %s: %v", endpoint, err)
+	}
+	if err := client.Ping(ctx, nil); err != nil {
+		t.Fatalf("ping %s: %v", endpoint, err)
+	}
+	t.Cleanup(func() { _ = client.Disconnect(context.Background()) })
+	return client
+}
+
+// syncTask builds the configuration for one collection, mirroring what the
+// loader produces from a task's config_json.
+func syncTask(t *testing.T, collection string, tables ...config.TableMapping) config.SyncConfig {
+	t.Helper()
+
+	srcHost, srcPort := harness.SplitHostPort(t, harness.MongoSource)
+	tgtHost, tgtPort := harness.SplitHostPort(t, harness.MongoTarget)
+
+	if len(tables) == 0 {
+		tables = []config.TableMapping{{SourceTable: collection, TargetTable: collection}}
+	}
+
+	return config.SyncConfig{
+		ID:     1,
+		Enable: true,
+		Type:   "mongodb",
+		SourceConnection: config.BuildDSNByType("mongodb", map[string]string{
+			"host": srcHost, "port": srcPort, "database": sourceDB,
+		}),
+		TargetConnection: config.BuildDSNByType("mongodb", map[string]string{
+			"host": tgtHost, "port": tgtPort, "database": targetDB,
+		}),
+		MongoDBResumeTokenPath: t.TempDir(),
+		Mappings:               []config.DatabaseMapping{{Tables: tables}},
+	}
+}
+
+func startSyncer(t *testing.T, cfg config.SyncConfig) (stop func()) {
+	t.Helper()
+
+	logger := logrus.New()
+	logger.SetLevel(logrus.ErrorLevel)
+
+	syncer := NewMongoDBSyncer(cfg, &config.Config{}, logger)
+	if syncer == nil {
+		t.Fatal("NewMongoDBSyncer returned nil; the endpoints are probably unreachable")
+	}
+
+	stop = harness.RunSyncer(t, syncer.Start)
+	t.Cleanup(stop)
+	return stop
+}
+
+// countIn reports how many documents match filter in the given collection.
+func countIn(t *testing.T, client *mongo.Client, db, coll string, filter interface{}) int64 {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	n, err := client.Database(db).Collection(coll).CountDocuments(ctx, filter)
+	if err != nil {
+		t.Fatalf("count %s.%s: %v", db, coll, err)
+	}
+	return n
+}
+
+func findOne(t *testing.T, client *mongo.Client, db, coll string, filter interface{}) (bson.M, error) {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	var doc bson.M
+	err := client.Database(db).Collection(coll).FindOne(ctx, filter).Decode(&doc)
+	return doc, err
+}
+
+func TestInitialSyncCopiesExistingDocuments(t *testing.T) {
+	collection := harness.UniqueName("initial")
+	src, tgt := connect(t, harness.MongoSource), connect(t, harness.MongoTarget)
+	ctx := context.Background()
+
+	const total = 50
+	docs := make([]interface{}, 0, total)
+	for i := 0; i < total; i++ {
+		docs = append(docs, bson.M{"seq": i, "name": fmt.Sprintf("user_%d", i)})
+	}
+	if _, err := src.Database(sourceDB).Collection(collection).InsertMany(ctx, docs); err != nil {
+		t.Fatalf("seed source: %v", err)
+	}
+
+	startSyncer(t, syncTask(t, collection))
+
+	harness.Eventually(t, 30*time.Second, func() error {
+		if n := countIn(t, tgt, targetDB, collection, bson.M{}); n != total {
+			return fmt.Errorf("target holds %d documents, want %d", n, total)
+		}
+		return nil
+	})
+}
+
+func TestIncrementalSyncAppliesInsertUpdateDelete(t *testing.T) {
+	collection := harness.UniqueName("incremental")
+	src, tgt := connect(t, harness.MongoSource), connect(t, harness.MongoTarget)
+	ctx := context.Background()
+	srcColl := src.Database(sourceDB).Collection(collection)
+
+	// Seed one document so the collection exists before the watcher starts.
+	if _, err := srcColl.InsertOne(ctx, bson.M{"seq": 0, "name": "seed"}); err != nil {
+		t.Fatalf("seed source: %v", err)
+	}
+
+	startSyncer(t, syncTask(t, collection))
+	harness.Eventually(t, 30*time.Second, func() error {
+		if n := countIn(t, tgt, targetDB, collection, bson.M{}); n != 1 {
+			return fmt.Errorf("initial sync has not landed: %d documents", n)
+		}
+		return nil
+	})
+
+	t.Run("insert", func(t *testing.T) {
+		if _, err := srcColl.InsertOne(ctx, bson.M{"seq": 1, "name": "inserted"}); err != nil {
+			t.Fatalf("insert: %v", err)
+		}
+		harness.Eventually(t, 20*time.Second, func() error {
+			if n := countIn(t, tgt, targetDB, collection, bson.M{"seq": 1}); n != 1 {
+				return fmt.Errorf("insert has not arrived")
+			}
+			return nil
+		})
+	})
+
+	t.Run("update", func(t *testing.T) {
+		if _, err := srcColl.UpdateOne(ctx, bson.M{"seq": 1}, bson.M{"$set": bson.M{"name": "updated"}}); err != nil {
+			t.Fatalf("update: %v", err)
+		}
+		harness.Eventually(t, 20*time.Second, func() error {
+			doc, err := findOne(t, tgt, targetDB, collection, bson.M{"seq": 1})
+			if err != nil {
+				return fmt.Errorf("document is gone: %w", err)
+			}
+			if doc["name"] != "updated" {
+				return fmt.Errorf("name is %v, want updated", doc["name"])
+			}
+			return nil
+		})
+	})
+
+	t.Run("delete", func(t *testing.T) {
+		if _, err := srcColl.DeleteOne(ctx, bson.M{"seq": 1}); err != nil {
+			t.Fatalf("delete: %v", err)
+		}
+		harness.Eventually(t, 20*time.Second, func() error {
+			if n := countIn(t, tgt, targetDB, collection, bson.M{"seq": 1}); n != 0 {
+				return fmt.Errorf("delete has not arrived: %d documents remain", n)
+			}
+			return nil
+		})
+	})
+}
+
+// TestSecurityPolicyIsIgnoredForMongoDB demonstrates F-104 end to end: the task
+// declares a masking rule, the syncer accepts it, and the target receives the
+// value in the clear. MySQL and PostgreSQL apply the same configuration; the
+// MongoDB path never calls the security package at all.
+func TestSecurityPolicyIsIgnoredForMongoDB(t *testing.T) {
+	collection := harness.UniqueName("security")
+	src, tgt := connect(t, harness.MongoSource), connect(t, harness.MongoTarget)
+	ctx := context.Background()
+
+	const email = "jack@example.com"
+	if _, err := src.Database(sourceDB).Collection(collection).InsertOne(ctx,
+		bson.M{"seq": 1, "email": email}); err != nil {
+		t.Fatalf("seed source: %v", err)
+	}
+
+	cfg := syncTask(t, collection, config.TableMapping{
+		SourceTable:     collection,
+		TargetTable:     collection,
+		SecurityEnabled: true,
+		FieldSecurity: []interface{}{
+			map[string]interface{}{"field": "email", "securityType": "masked"},
+		},
+	})
+	startSyncer(t, cfg)
+
+	harness.Eventually(t, 30*time.Second, func() error {
+		doc, err := findOne(t, tgt, targetDB, collection, bson.M{"seq": 1})
+		if err != nil {
+			return fmt.Errorf("document has not arrived: %w", err)
+		}
+		if doc["email"] == nil {
+			return fmt.Errorf("email field is missing")
+		}
+		return nil
+	})
+
+	doc, err := findOne(t, tgt, targetDB, collection, bson.M{"seq": 1})
+	if err != nil {
+		t.Fatalf("read target: %v", err)
+	}
+	if doc["email"] != email {
+		t.Fatalf("target holds %v; masking now appears to run for MongoDB, "+
+			"so assert the masked value instead", doc["email"])
+	}
+}

--- a/pkg/syncer/mysql/integration_test.go
+++ b/pkg/syncer/mysql/integration_test.go
@@ -1,0 +1,518 @@
+//go:build integration
+
+package mysql
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"testing"
+	"time"
+
+	_ "github.com/go-sql-driver/mysql"
+	"github.com/sirupsen/logrus"
+
+	"github.com/retail-ai-inc/sync/pkg/config"
+	"github.com/retail-ai-inc/sync/test/harness"
+)
+
+const (
+	sourceDB = "source_db"
+	targetDB = "target_db"
+)
+
+func open(t *testing.T, endpoint, database string) *sql.DB {
+	t.Helper()
+
+	host, port := harness.SplitHostPort(t, endpoint)
+	dsn := config.BuildDSNByType("mysql", map[string]string{
+		"user": "root", "password": "root", "host": host, "port": port, "database": database,
+	})
+
+	db, err := sql.Open("mysql", dsn)
+	if err != nil {
+		t.Fatalf("open %s: %v", endpoint, err)
+	}
+	if err := db.Ping(); err != nil {
+		t.Fatalf("ping %s: %v", endpoint, err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	return db
+}
+
+func mustExec(t *testing.T, db *sql.DB, query string, args ...interface{}) {
+	t.Helper()
+
+	if _, err := db.Exec(query, args...); err != nil {
+		t.Fatalf("exec %q: %v", query, err)
+	}
+}
+
+func countRows(t *testing.T, db *sql.DB, table, where string, args ...interface{}) int {
+	t.Helper()
+
+	query := fmt.Sprintf("SELECT COUNT(*) FROM %s", table)
+	if where != "" {
+		query += " WHERE " + where
+	}
+	var n int
+	if err := db.QueryRow(query, args...).Scan(&n); err != nil {
+		return -1 // the table may not exist yet; callers poll on the value
+	}
+	return n
+}
+
+func syncTask(t *testing.T, table string, tables ...config.TableMapping) config.SyncConfig {
+	t.Helper()
+
+	srcHost, srcPort := harness.SplitHostPort(t, harness.MySQLSource)
+	tgtHost, tgtPort := harness.SplitHostPort(t, harness.MySQLTarget)
+
+	if len(tables) == 0 {
+		tables = []config.TableMapping{{SourceTable: table, TargetTable: table}}
+	}
+
+	return config.SyncConfig{
+		ID:     1,
+		Enable: true,
+		Type:   "mysql",
+		SourceConnection: config.BuildDSNByType("mysql", map[string]string{
+			"user": "root", "password": "root", "host": srcHost, "port": srcPort, "database": sourceDB,
+		}),
+		TargetConnection: config.BuildDSNByType("mysql", map[string]string{
+			"user": "root", "password": "root", "host": tgtHost, "port": tgtPort, "database": targetDB,
+		}),
+		MySQLPositionPath: t.TempDir() + "/binlog.pos",
+		Mappings:          []config.DatabaseMapping{{Tables: tables}},
+	}
+}
+
+func startSyncer(t *testing.T, cfg config.SyncConfig) (stop func()) {
+	t.Helper()
+
+	logger := logrus.New()
+	logger.SetLevel(logrus.ErrorLevel)
+
+	syncer := NewMySQLSyncer(cfg, logger)
+	if syncer == nil {
+		t.Fatal("NewMySQLSyncer returned nil")
+	}
+	stop = harness.RunSyncer(t, func(ctx context.Context) { syncer.Start(ctx) })
+	t.Cleanup(stop)
+	return stop
+}
+
+// createSourceTable makes a uniquely named table on the source and removes both
+// copies afterwards.
+func createSourceTable(t *testing.T, src, tgt *sql.DB, table string) {
+	t.Helper()
+
+	mustExec(t, src, fmt.Sprintf(
+		`CREATE TABLE %s (id INT PRIMARY KEY, name VARCHAR(100))`, table))
+	t.Cleanup(func() {
+		_, _ = src.Exec("DROP TABLE IF EXISTS " + table)
+		_, _ = tgt.Exec("DROP TABLE IF EXISTS " + table)
+	})
+}
+
+func TestInitialSyncCreatesTargetTableAndCopiesRows(t *testing.T) {
+	table := harness.UniqueName("initial")
+	src, tgt := open(t, harness.MySQLSource, sourceDB), open(t, harness.MySQLTarget, targetDB)
+
+	createSourceTable(t, src, tgt, table)
+	for i := 1; i <= 20; i++ {
+		mustExec(t, src, fmt.Sprintf("INSERT INTO %s (id, name) VALUES (?, ?)", table), i, fmt.Sprintf("user_%d", i))
+	}
+
+	startSyncer(t, syncTask(t, table))
+
+	harness.Eventually(t, 45*time.Second, func() error {
+		if n := countRows(t, tgt, table, ""); n != 20 {
+			return fmt.Errorf("target holds %d rows, want 20", n)
+		}
+		return nil
+	})
+}
+
+func TestIncrementalSyncAppliesInsertUpdateDelete(t *testing.T) {
+	table := harness.UniqueName("incremental")
+	src, tgt := open(t, harness.MySQLSource, sourceDB), open(t, harness.MySQLTarget, targetDB)
+
+	createSourceTable(t, src, tgt, table)
+	mustExec(t, src, fmt.Sprintf("INSERT INTO %s (id, name) VALUES (1, 'seed')", table))
+
+	startSyncer(t, syncTask(t, table))
+	harness.Eventually(t, 45*time.Second, func() error {
+		if n := countRows(t, tgt, table, ""); n != 1 {
+			return fmt.Errorf("initial sync has not landed: %d rows", n)
+		}
+		return nil
+	})
+
+	t.Run("insert", func(t *testing.T) {
+		mustExec(t, src, fmt.Sprintf("INSERT INTO %s (id, name) VALUES (2, 'inserted')", table))
+		harness.Eventually(t, 20*time.Second, func() error {
+			if n := countRows(t, tgt, table, "id = 2"); n != 1 {
+				return fmt.Errorf("insert has not arrived")
+			}
+			return nil
+		})
+	})
+
+	t.Run("update", func(t *testing.T) {
+		mustExec(t, src, fmt.Sprintf("UPDATE %s SET name = 'updated' WHERE id = 2", table))
+		harness.Eventually(t, 20*time.Second, func() error {
+			if n := countRows(t, tgt, table, "id = 2 AND name = 'updated'"); n != 1 {
+				return fmt.Errorf("update has not arrived")
+			}
+			return nil
+		})
+	})
+
+	t.Run("delete", func(t *testing.T) {
+		mustExec(t, src, fmt.Sprintf("DELETE FROM %s WHERE id = 2", table))
+		harness.Eventually(t, 20*time.Second, func() error {
+			if n := countRows(t, tgt, table, "id = 2"); n != 0 {
+				return fmt.Errorf("delete has not arrived")
+			}
+			return nil
+		})
+	})
+}
+
+// TestDDLIsPropagated exercises F-044. MyEventHandler implements only OnRow and
+// OnPosSynced, so canal's no-op OnDDL and OnTableChanged handle schema changes.
+// A column added at the source never reaches the target, and the rows that use
+// it cannot be replicated afterwards.
+func TestDDLIsPropagated(t *testing.T) {
+	table := harness.UniqueName("ddl")
+	src, tgt := open(t, harness.MySQLSource, sourceDB), open(t, harness.MySQLTarget, targetDB)
+
+	createSourceTable(t, src, tgt, table)
+	mustExec(t, src, fmt.Sprintf("INSERT INTO %s (id, name) VALUES (1, 'before')", table))
+
+	startSyncer(t, syncTask(t, table))
+	harness.Eventually(t, 45*time.Second, func() error {
+		if n := countRows(t, tgt, table, ""); n != 1 {
+			return fmt.Errorf("initial sync has not landed: %d rows", n)
+		}
+		return nil
+	})
+
+	// A schema change of the kind any live service eventually performs.
+	mustExec(t, src, fmt.Sprintf("ALTER TABLE %s ADD COLUMN email VARCHAR(100)", table))
+	mustExec(t, src, fmt.Sprintf("INSERT INTO %s (id, name, email) VALUES (2, 'after', 'a@b.com')", table))
+
+	// Poll rather than sleep a fixed window: the column and the row never
+	// arrive while the defect stands, so this costs the full window, but it
+	// returns at once if DDL propagation is ever implemented.
+	emailColumns := func() int {
+		t.Helper()
+		var n int
+		if err := tgt.QueryRow(`
+			SELECT COUNT(*) FROM information_schema.columns
+			WHERE table_schema = ? AND table_name = ? AND column_name = 'email'`,
+			targetDB, table).Scan(&n); err != nil {
+			t.Fatalf("inspect target schema: %v", err)
+		}
+		return n
+	}
+	harness.WaitFor(4*time.Second, func() error {
+		if emailColumns() == 0 && countRows(t, tgt, table, "id = 2") == 0 {
+			return fmt.Errorf("neither the column nor the row has arrived")
+		}
+		return nil
+	})
+
+	columnCount := emailColumns()
+	rowsOnTarget := countRows(t, tgt, table, "id = 2")
+
+	if columnCount != 0 {
+		t.Fatalf("the target gained the email column; DDL replication appears to " +
+			"have been implemented, so assert the propagated schema instead")
+	}
+	t.Errorf("the source column `email` was not propagated and the row written "+
+		"after the ALTER %s on the target (F-044): a schema change at the source "+
+		"silently stops replication for the affected rows",
+		map[bool]string{true: "did land", false: "never landed"}[rowsOnTarget == 1])
+}
+
+// TestSecurityPolicyIsAppliedToMySQL is the counterpart to the MongoDB case:
+// the same configuration that MongoDB ignores does take effect here, which is
+// what makes the gap a per-engine inconsistency rather than a missing feature.
+func TestSecurityPolicyIsAppliedToMySQL(t *testing.T) {
+	table := harness.UniqueName("security")
+	src, tgt := open(t, harness.MySQLSource, sourceDB), open(t, harness.MySQLTarget, targetDB)
+
+	mustExec(t, src, fmt.Sprintf(
+		`CREATE TABLE %s (id INT PRIMARY KEY, email VARCHAR(100))`, table))
+	t.Cleanup(func() {
+		_, _ = src.Exec("DROP TABLE IF EXISTS " + table)
+		_, _ = tgt.Exec("DROP TABLE IF EXISTS " + table)
+	})
+	mustExec(t, src, fmt.Sprintf("INSERT INTO %s (id, email) VALUES (1, 'jack@example.com')", table))
+
+	cfg := syncTask(t, table, config.TableMapping{
+		SourceTable:     table,
+		TargetTable:     table,
+		SecurityEnabled: true,
+		FieldSecurity: []interface{}{
+			map[string]interface{}{"field": "email", "securityType": "masked"},
+		},
+	})
+	startSyncer(t, cfg)
+
+	harness.Eventually(t, 45*time.Second, func() error {
+		if n := countRows(t, tgt, table, ""); n != 1 {
+			return fmt.Errorf("initial sync has not landed: %d rows", n)
+		}
+		return nil
+	})
+
+	var email string
+	if err := tgt.QueryRow(fmt.Sprintf("SELECT email FROM %s WHERE id = 1", table)).Scan(&email); err != nil {
+		t.Fatalf("read target: %v", err)
+	}
+	if email == "jack@example.com" {
+		t.Fatalf("the target holds the address in the clear; masking has stopped " +
+			"working for MySQL as well")
+	}
+	t.Logf("MySQL masked the value to %q, while MongoDB leaves it in the clear", email)
+}
+
+// TestWritesDuringInitialSyncAreNotLost exercises F-040, the MySQL counterpart
+// of the MongoDB snapshot gap. doInitialSync copies rows with batched INSERTs
+// and only then starts canal, which with no stored position begins from the
+// master's current coordinates. Rows written between the copy and that call
+// belong to neither path.
+func TestWritesDuringInitialSyncAreNotLost(t *testing.T) {
+	table := harness.UniqueName("snapshotgap")
+	src, tgt := open(t, harness.MySQLSource, sourceDB), open(t, harness.MySQLTarget, targetDB)
+
+	createSourceTable(t, src, tgt, table)
+
+	// Large enough that the batched copy takes seconds rather than milliseconds.
+	const seeded = 20000
+	mustExec(t, src, "SET autocommit = 0")
+	for i := 1; i <= seeded; i += 500 {
+		values := ""
+		for j := i; j < i+500 && j <= seeded; j++ {
+			if values != "" {
+				values += ","
+			}
+			values += fmt.Sprintf("(%d,'user_%d')", j, j)
+		}
+		mustExec(t, src, fmt.Sprintf("INSERT INTO %s (id, name) VALUES %s", table, values))
+	}
+	mustExec(t, src, "COMMIT")
+	mustExec(t, src, "SET autocommit = 1")
+
+	startSyncer(t, syncTask(t, table))
+
+	// Write markers while the copy is still running.
+	markers := 0
+	deadline := time.Now().Add(6 * time.Second)
+	for time.Now().Before(deadline) {
+		copied := countRows(t, tgt, table, "")
+		if copied >= seeded {
+			break
+		}
+		mustExec(t, src, fmt.Sprintf("INSERT INTO %s (id, name) VALUES (?, 'marker')", table), 900000+markers)
+		markers++
+		time.Sleep(150 * time.Millisecond)
+	}
+	if markers == 0 {
+		t.Skip("the copy finished too quickly to write a marker; raise the seed size")
+	}
+	t.Logf("wrote %d markers while the initial copy was running", markers)
+
+	harness.Eventually(t, 120*time.Second, func() error {
+		if n := countRows(t, tgt, table, "id <= ?", seeded); n != seeded {
+			return fmt.Errorf("copy still running: %d of %d seeded rows", n, seeded)
+		}
+		return nil
+	})
+
+	arrived := countRows(t, tgt, table, "name = 'marker'")
+	if arrived != markers {
+		t.Errorf("%d of %d rows written during the initial copy reached the target; "+
+			"writes in the window between the copy and canal starting are lost (F-040)",
+			arrived, markers)
+	}
+}
+
+// TestResumeFromStoredBinlogPosition checks that a restarted syncer replays what
+// it missed. The position file lives under MySQLPositionPath, so the second run
+// must reuse the same path.
+func TestResumeFromStoredBinlogPosition(t *testing.T) {
+	table := harness.UniqueName("resume")
+	src, tgt := open(t, harness.MySQLSource, sourceDB), open(t, harness.MySQLTarget, targetDB)
+
+	createSourceTable(t, src, tgt, table)
+	mustExec(t, src, fmt.Sprintf("INSERT INTO %s (id, name) VALUES (1, 'seed')", table))
+
+	positionPath := t.TempDir() + "/binlog.pos"
+	newCfg := func() config.SyncConfig {
+		cfg := syncTask(t, table)
+		cfg.MySQLPositionPath = positionPath
+		return cfg
+	}
+
+	stop := startSyncer(t, newCfg())
+	harness.Eventually(t, 45*time.Second, func() error {
+		if n := countRows(t, tgt, table, ""); n != 1 {
+			return fmt.Errorf("initial sync has not landed: %d rows", n)
+		}
+		return nil
+	})
+
+	// One change while running, so a position is definitely persisted.
+	mustExec(t, src, fmt.Sprintf("INSERT INTO %s (id, name) VALUES (2, 'while running')", table))
+	harness.Eventually(t, 20*time.Second, func() error {
+		if n := countRows(t, tgt, table, "id = 2"); n != 1 {
+			return fmt.Errorf("the first change has not arrived")
+		}
+		return nil
+	})
+
+	stop()
+	time.Sleep(2 * time.Second)
+
+	// Written while nothing is reading the binlog.
+	mustExec(t, src, fmt.Sprintf("INSERT INTO %s (id, name) VALUES (3, 'while stopped')", table))
+
+	startSyncer(t, newCfg())
+
+	harness.Eventually(t, 45*time.Second, func() error {
+		if n := countRows(t, tgt, table, "id = 3"); n != 1 {
+			return fmt.Errorf("the row written while the syncer was stopped has not " +
+				"been replayed; resuming from the stored binlog position is not working")
+		}
+		return nil
+	})
+}
+
+// TestTransactionBoundariesAreObserved exercises F-045. MyEventHandler.OnRow
+// applies each row event on its own as it arrives; there is no XID grouping and
+// no transaction on the target, so a multi-row transaction at the source is
+// replayed as a sequence of independent statements. A reader on the target can
+// therefore observe a state that never existed at the source.
+//
+// The scenario keeps a two-row invariant — the balances must always sum to the
+// same constant — and transfers between the rows inside explicit transactions
+// while polling the target. Any observation with a different sum means the
+// invariant was broken in flight.
+func TestTransactionBoundariesAreObserved(t *testing.T) {
+	table := harness.UniqueName("txn")
+	src, tgt := open(t, harness.MySQLSource, sourceDB), open(t, harness.MySQLTarget, targetDB)
+
+	mustExec(t, src, fmt.Sprintf(
+		`CREATE TABLE %s (id INT PRIMARY KEY, balance INT NOT NULL)`, table))
+	t.Cleanup(func() {
+		_, _ = src.Exec("DROP TABLE IF EXISTS " + table)
+		_, _ = tgt.Exec("DROP TABLE IF EXISTS " + table)
+	})
+	mustExec(t, src, fmt.Sprintf("INSERT INTO %s (id, balance) VALUES (1, 1000), (2, 1000)", table))
+
+	const total = 2000
+
+	startSyncer(t, syncTask(t, table))
+	harness.Eventually(t, 45*time.Second, func() error {
+		var sum int
+		if err := tgt.QueryRow(fmt.Sprintf("SELECT COALESCE(SUM(balance), -1) FROM %s", table)).Scan(&sum); err != nil {
+			return fmt.Errorf("target not ready: %w", err)
+		}
+		if sum != total {
+			return fmt.Errorf("initial sync has not landed: sum is %d", sum)
+		}
+		return nil
+	})
+
+	// Poll the target while transfers run and record any sum that breaks the
+	// invariant.
+	stopPolling := make(chan struct{})
+	violations := make(chan int, 64)
+	go func() {
+		defer close(violations)
+		for {
+			select {
+			case <-stopPolling:
+				return
+			default:
+				var sum int
+				if err := tgt.QueryRow(fmt.Sprintf("SELECT COALESCE(SUM(balance), %d) FROM %s", total, table)).Scan(&sum); err == nil && sum != total {
+					select {
+					case violations <- sum:
+					default:
+					}
+				}
+			}
+		}
+	}()
+
+	for i := 0; i < 200; i++ {
+		tx, err := src.Begin()
+		if err != nil {
+			t.Fatalf("begin: %v", err)
+		}
+		if _, err := tx.Exec(fmt.Sprintf("UPDATE %s SET balance = balance - 100 WHERE id = 1", table)); err != nil {
+			t.Fatalf("debit: %v", err)
+		}
+		if _, err := tx.Exec(fmt.Sprintf("UPDATE %s SET balance = balance + 100 WHERE id = 2", table)); err != nil {
+			t.Fatalf("credit: %v", err)
+		}
+		if err := tx.Commit(); err != nil {
+			t.Fatalf("commit: %v", err)
+		}
+		// Reverse it so the balances stay in range.
+		tx, err = src.Begin()
+		if err != nil {
+			t.Fatalf("begin: %v", err)
+		}
+		if _, err := tx.Exec(fmt.Sprintf("UPDATE %s SET balance = balance + 100 WHERE id = 1", table)); err != nil {
+			t.Fatalf("credit back: %v", err)
+		}
+		if _, err := tx.Exec(fmt.Sprintf("UPDATE %s SET balance = balance - 100 WHERE id = 2", table)); err != nil {
+			t.Fatalf("debit back: %v", err)
+		}
+		if err := tx.Commit(); err != nil {
+			t.Fatalf("commit: %v", err)
+		}
+	}
+
+	// Let replication drain, then stop polling.
+	time.Sleep(5 * time.Second)
+	close(stopPolling)
+
+	var observed []int
+	for sum := range violations {
+		observed = append(observed, sum)
+		if len(observed) >= 5 {
+			break
+		}
+	}
+
+	// The end state must be correct regardless.
+	var finalSum int
+	if err := tgt.QueryRow(fmt.Sprintf("SELECT SUM(balance) FROM %s", table)).Scan(&finalSum); err != nil {
+		t.Fatalf("read final sum: %v", err)
+	}
+	if finalSum != total {
+		t.Errorf("the target settled on a sum of %d, want %d", finalSum, total)
+	}
+
+	if len(observed) == 0 {
+		t.Skip("no intermediate state was caught; the window is narrow and the " +
+			"poller may simply have missed it")
+	}
+	t.Errorf("the target exposed %d intermediate sums such as %v, none of which "+
+		"ever existed at the source: row events are applied individually with no "+
+		"transaction around them (F-045)", len(observed), observed[:min(len(observed), 3)])
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/pkg/syncer/mysql/mysql_test.go
+++ b/pkg/syncer/mysql/mysql_test.go
@@ -1,0 +1,195 @@
+package mysql
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/go-mysql-org/go-mysql/mysql"
+	"github.com/sirupsen/logrus"
+)
+
+func newSyncer(t *testing.T) *MySQLSyncer {
+	t.Helper()
+
+	logger := logrus.New()
+	logger.SetLevel(logrus.PanicLevel)
+	return &MySQLSyncer{logger: logger}
+}
+
+func TestParseAddr(t *testing.T) {
+	s := newSyncer(t)
+
+	tests := []struct {
+		name string
+		dsn  string
+		want string
+	}{
+		{"standard", "root:root@tcp(localhost:3306)/source_db", "localhost:3306"},
+		{"with parameters", "root:root@tcp(db:3307)/source_db?charset=utf8", "db:3307"},
+		{"no database", "root:root@tcp(db:3306)/", "db:3306"},
+		{"not a tcp dsn", "root:root@unix(/tmp/mysql.sock)/db", ""},
+		{"empty", "", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := s.parseAddr(tt.dsn); got != tt.want {
+				t.Errorf("parseAddr(%q) = %q, want %q", tt.dsn, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseUserPassword(t *testing.T) {
+	s := newSyncer(t)
+
+	tests := []struct {
+		name           string
+		dsn            string
+		wantUser, want string
+	}{
+		{"standard", "root:secret@tcp(localhost:3306)/db", "root", "secret"},
+		{"no credentials", "tcp(localhost:3306)/db", "", ""},
+		{"user without password", "root@tcp(localhost:3306)/db", "", ""},
+		{"empty", "", "", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			user, pass := s.parseUserPassword(tt.dsn)
+			if user != tt.wantUser || pass != tt.want {
+				t.Errorf("parseUserPassword(%q) = %q/%q, want %q/%q",
+					tt.dsn, user, pass, tt.wantUser, tt.want)
+			}
+		})
+	}
+}
+
+// TestParseUserPasswordTruncatesOnSpecialCharacters records that credentials
+// are recovered by splitting the DSN on "@" and then on ":", with no awareness
+// that either character is legal inside a password. A password containing one
+// is silently truncated, and the syncer then fails to authenticate with an
+// error that says nothing about the mangled credential.
+//
+// The DSN is assembled by config.buildDSNByType from the values an operator
+// typed into the UI, so nothing rejects such a password earlier either.
+func TestParseUserPasswordTruncatesOnSpecialCharacters(t *testing.T) {
+	s := newSyncer(t)
+
+	tests := []struct {
+		name           string
+		dsn            string
+		wantUser, want string
+	}{
+		{
+			"at sign in the password",
+			"root:p@ss@tcp(localhost:3306)/db",
+			"root", "p", // want root/p@ss
+		},
+		{
+			"colon in the password",
+			"root:pa:ss@tcp(localhost:3306)/db",
+			"root", "pa", // want root/pa:ss
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			user, pass := s.parseUserPassword(tt.dsn)
+			if pass == "p@ss" || pass == "pa:ss" {
+				t.Fatalf("the password now survives (%q); parsing may have been "+
+					"fixed, so assert the correct value instead", pass)
+			}
+			if user != tt.wantUser || pass != tt.want {
+				t.Errorf("parseUserPassword(%q) = %q/%q, want %q/%q",
+					tt.dsn, user, pass, tt.wantUser, tt.want)
+			}
+		})
+	}
+}
+
+func TestMakeQuestionMarks(t *testing.T) {
+	tests := []struct {
+		n    int
+		want string
+	}{
+		{0, ""},
+		{1, "?"},
+		{3, "?,?,?"},
+	}
+
+	for _, tt := range tests {
+		got := makeQuestionMarks(tt.n)
+		if len(got) != tt.n {
+			t.Errorf("makeQuestionMarks(%d) has %d elements, want %d", tt.n, len(got), tt.n)
+		}
+		if joined := strings.Join(got, ","); joined != tt.want {
+			t.Errorf("makeQuestionMarks(%d) = %q, want %q", tt.n, joined, tt.want)
+		}
+	}
+}
+
+func TestLoadBinlogPosition(t *testing.T) {
+	s := newSyncer(t)
+	dir := t.TempDir()
+
+	t.Run("round trips a saved position", func(t *testing.T) {
+		path := filepath.Join(dir, "binlog.pos")
+		want := mysql.Position{Name: "mysql-bin.000042", Pos: 1234}
+		data, err := json.Marshal(want)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		if err := os.WriteFile(path, data, 0o644); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+
+		got := s.loadBinlogPosition(path)
+		if got == nil {
+			t.Fatal("loadBinlogPosition returned nil for a valid file")
+		}
+		if got.Name != want.Name || got.Pos != want.Pos {
+			t.Errorf("position = %v, want %v", *got, want)
+		}
+	})
+
+	t.Run("missing file yields nil", func(t *testing.T) {
+		if got := s.loadBinlogPosition(filepath.Join(dir, "absent.pos")); got != nil {
+			t.Errorf("loadBinlogPosition = %v, want nil", *got)
+		}
+	})
+
+	t.Run("empty file yields nil", func(t *testing.T) {
+		path := filepath.Join(dir, "empty.pos")
+		if err := os.WriteFile(path, nil, 0o644); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+		if got := s.loadBinlogPosition(path); got != nil {
+			t.Errorf("loadBinlogPosition = %v, want nil", *got)
+		}
+	})
+
+	t.Run("malformed file yields nil", func(t *testing.T) {
+		path := filepath.Join(dir, "bad.pos")
+		if err := os.WriteFile(path, []byte("{not json"), 0o644); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+		// A corrupt position file is indistinguishable from a missing one, so
+		// the syncer silently restarts from the master's current coordinates
+		// and everything written in between is skipped.
+		if got := s.loadBinlogPosition(path); got != nil {
+			t.Errorf("loadBinlogPosition = %v, want nil", *got)
+		}
+	})
+
+	t.Run("creates the parent directory", func(t *testing.T) {
+		path := filepath.Join(dir, "nested", "deep", "binlog.pos")
+		s.loadBinlogPosition(path)
+		if _, err := os.Stat(filepath.Dir(path)); err != nil {
+			t.Errorf("the parent directory was not created: %v", err)
+		}
+	})
+}

--- a/pkg/syncer/redis/integration_test.go
+++ b/pkg/syncer/redis/integration_test.go
@@ -1,0 +1,441 @@
+//go:build integration
+
+package redis
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	goredis "github.com/redis/go-redis/v9"
+	"github.com/sirupsen/logrus"
+
+	"github.com/retail-ai-inc/sync/pkg/config"
+	"github.com/retail-ai-inc/sync/test/harness"
+)
+
+func client(t *testing.T, endpoint string, db int) *goredis.Client {
+	t.Helper()
+
+	c := goredis.NewClient(&goredis.Options{Addr: endpoint, DB: db})
+	if err := c.Ping(context.Background()).Err(); err != nil {
+		t.Fatalf("ping %s db%d: %v", endpoint, db, err)
+	}
+	t.Cleanup(func() { _ = c.Close() })
+	return c
+}
+
+func syncTask(t *testing.T, db string) config.SyncConfig {
+	t.Helper()
+
+	srcHost, srcPort := harness.SplitHostPort(t, harness.RedisSource)
+	tgtHost, tgtPort := harness.SplitHostPort(t, harness.RedisTarget)
+
+	return config.SyncConfig{
+		ID:     1,
+		Enable: true,
+		Type:   "redis",
+		SourceConnection: config.BuildDSNByType("redis", map[string]string{
+			"host": srcHost, "port": srcPort, "database": db,
+		}),
+		TargetConnection: config.BuildDSNByType("redis", map[string]string{
+			"host": tgtHost, "port": tgtPort, "database": db,
+		}),
+		RedisPositionPath: t.TempDir() + "/redis.pos",
+		// A stream mapping is mandatory: Start indexes Mappings[0].Tables[0]
+		// without a bounds check, see TestStartPanicsWithoutTableMapping.
+		Mappings: []config.DatabaseMapping{{Tables: []config.TableMapping{
+			{SourceTable: "sync_stream", TargetTable: "sync_stream"},
+		}}},
+	}
+}
+
+func startSyncer(t *testing.T, cfg config.SyncConfig) (stop func()) {
+	t.Helper()
+
+	logger := logrus.New()
+	logger.SetLevel(logrus.ErrorLevel)
+
+	syncer := NewRedisSyncer(cfg, logger)
+	if syncer == nil {
+		t.Fatal("NewRedisSyncer returned nil")
+	}
+	stop = harness.RunSyncer(t, syncer.Start)
+	t.Cleanup(stop)
+	return stop
+}
+
+// flush clears both sides so each test starts from a known state; the syncer
+// copies every key it finds, so leftovers from one test would confuse the next.
+func flush(t *testing.T, dbs ...int) {
+	t.Helper()
+
+	ctx := context.Background()
+	for _, db := range dbs {
+		for _, endpoint := range []string{harness.RedisSource, harness.RedisTarget} {
+			c := goredis.NewClient(&goredis.Options{Addr: endpoint, DB: db})
+			if err := c.FlushDB(ctx).Err(); err != nil {
+				t.Fatalf("flush %s db%d: %v", endpoint, db, err)
+			}
+			_ = c.Close()
+		}
+	}
+}
+
+func TestInitialSyncCopiesExistingKeys(t *testing.T) {
+	flush(t, 0)
+	src, tgt := client(t, harness.RedisSource, 0), client(t, harness.RedisTarget, 0)
+	ctx := context.Background()
+
+	// One key of each shape the DUMP/RESTORE path has to carry.
+	if err := src.Set(ctx, "str", "hello", 0).Err(); err != nil {
+		t.Fatalf("seed string: %v", err)
+	}
+	if err := src.HSet(ctx, "hash", "field", "value").Err(); err != nil {
+		t.Fatalf("seed hash: %v", err)
+	}
+	if err := src.RPush(ctx, "list", "a", "b", "c").Err(); err != nil {
+		t.Fatalf("seed list: %v", err)
+	}
+	if err := src.SAdd(ctx, "set", "x", "y").Err(); err != nil {
+		t.Fatalf("seed set: %v", err)
+	}
+	if err := src.ZAdd(ctx, "zset", goredis.Z{Score: 1, Member: "m"}).Err(); err != nil {
+		t.Fatalf("seed zset: %v", err)
+	}
+	if err := src.Set(ctx, "expiring", "v", time.Hour).Err(); err != nil {
+		t.Fatalf("seed expiring: %v", err)
+	}
+
+	startSyncer(t, syncTask(t, "0"))
+
+	harness.Eventually(t, 30*time.Second, func() error {
+		for _, key := range []string{"str", "hash", "list", "set", "zset", "expiring"} {
+			n, err := tgt.Exists(ctx, key).Result()
+			if err != nil {
+				return err
+			}
+			if n != 1 {
+				return fmt.Errorf("key %q has not arrived", key)
+			}
+		}
+		return nil
+	})
+
+	if got := tgt.Get(ctx, "str").Val(); got != "hello" {
+		t.Errorf("str = %q, want hello", got)
+	}
+	if got := tgt.LRange(ctx, "list", 0, -1).Val(); len(got) != 3 {
+		t.Errorf("list = %v, want three elements", got)
+	}
+	// TTLs must survive the copy, otherwise the target keeps data the source drops.
+	if ttl := tgt.TTL(ctx, "expiring").Val(); ttl <= 0 {
+		t.Errorf("expiring has TTL %v, want it preserved", ttl)
+	}
+}
+
+func TestIncrementalSyncAppliesSetAndDelete(t *testing.T) {
+	flush(t, 0)
+	src, tgt := client(t, harness.RedisSource, 0), client(t, harness.RedisTarget, 0)
+	ctx := context.Background()
+
+	if err := src.Set(ctx, "seed", "v", 0).Err(); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	startSyncer(t, syncTask(t, "0"))
+	harness.Eventually(t, 30*time.Second, func() error {
+		if tgt.Exists(ctx, "seed").Val() != 1 {
+			return fmt.Errorf("initial sync has not landed")
+		}
+		return nil
+	})
+
+	t.Run("set", func(t *testing.T) {
+		if err := src.Set(ctx, "added", "value", 0).Err(); err != nil {
+			t.Fatalf("set: %v", err)
+		}
+		harness.Eventually(t, 20*time.Second, func() error {
+			if got := tgt.Get(ctx, "added").Val(); got != "value" {
+				return fmt.Errorf("added = %q, want value", got)
+			}
+			return nil
+		})
+	})
+
+	t.Run("delete", func(t *testing.T) {
+		if err := src.Del(ctx, "added").Err(); err != nil {
+			t.Fatalf("del: %v", err)
+		}
+		harness.Eventually(t, 20*time.Second, func() error {
+			if tgt.Exists(ctx, "added").Val() != 0 {
+				return fmt.Errorf("the deletion has not arrived")
+			}
+			return nil
+		})
+	})
+}
+
+// TestKeyspaceNotificationsOnlyCoverDB0 exercises F-082. watchKeyspaceChanges
+// subscribes to the literal pattern __keyspace@0__:*, so a task configured for
+// any other database receives no incremental events at all: the initial copy
+// works and everything after it is silently dropped.
+func TestKeyspaceNotificationsOnlyCoverDB0(t *testing.T) {
+	flush(t, 1)
+	src, tgt := client(t, harness.RedisSource, 1), client(t, harness.RedisTarget, 1)
+	ctx := context.Background()
+
+	if err := src.Set(ctx, "before", "v", 0).Err(); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	startSyncer(t, syncTask(t, "1"))
+
+	// The initial copy uses SCAN against the configured database, so it works.
+	harness.Eventually(t, 30*time.Second, func() error {
+		if tgt.Exists(ctx, "before").Val() != 1 {
+			return fmt.Errorf("initial sync has not landed")
+		}
+		return nil
+	})
+
+	if err := src.Set(ctx, "after", "v", 0).Err(); err != nil {
+		t.Fatalf("write after start: %v", err)
+	}
+
+	// Incremental changes on db1 must reach the target.
+	// db1 writes never arrive, so this window is spent in full while the
+	// defect stands and exits immediately once it is fixed.
+	harness.Eventually(t, 5*time.Second, func() error {
+		if tgt.Exists(ctx, "after").Val() != 1 {
+			return fmt.Errorf("the key written after startup never arrived; keyspace " +
+				"notifications are subscribed on db0 only (F-082)")
+		}
+		return nil
+	})
+}
+
+// TestChangesWhileStoppedAreReplayed exercises F-081 and F-086 together. Redis
+// keyspace notifications are fire-and-forget: nothing is buffered while no
+// subscriber is listening, and the syncer stores no position it could resume
+// from. A restart therefore has to re-copy everything, and anything deleted
+// while it was down stays on the target for good.
+func TestChangesWhileStoppedAreReplayed(t *testing.T) {
+	flush(t, 0)
+	src, tgt := client(t, harness.RedisSource, 0), client(t, harness.RedisTarget, 0)
+	ctx := context.Background()
+
+	if err := src.Set(ctx, "kept", "v", 0).Err(); err != nil {
+		t.Fatalf("seed kept: %v", err)
+	}
+	if err := src.Set(ctx, "removed-while-down", "v", 0).Err(); err != nil {
+		t.Fatalf("seed removed: %v", err)
+	}
+
+	stop := startSyncer(t, syncTask(t, "0"))
+	harness.Eventually(t, 30*time.Second, func() error {
+		if tgt.Exists(ctx, "kept", "removed-while-down").Val() != 2 {
+			return fmt.Errorf("initial sync has not landed")
+		}
+		return nil
+	})
+
+	stop()
+	time.Sleep(time.Second)
+
+	// Both a creation and a deletion while nothing is subscribed.
+	if err := src.Set(ctx, "created-while-down", "v", 0).Err(); err != nil {
+		t.Fatalf("create while down: %v", err)
+	}
+	if err := src.Del(ctx, "removed-while-down").Err(); err != nil {
+		t.Fatalf("delete while down: %v", err)
+	}
+
+	startSyncer(t, syncTask(t, "0"))
+
+	// The re-run of the initial copy picks up the new key.
+	harness.Eventually(t, 30*time.Second, func() error {
+		if tgt.Exists(ctx, "created-while-down").Val() != 1 {
+			return fmt.Errorf("the key created while the syncer was down has not arrived")
+		}
+		return nil
+	})
+
+	// The deletion has no such safety net: SCAN only reports keys that exist,
+	// so a key removed at the source is never removed from the target.
+	if tgt.Exists(ctx, "removed-while-down").Val() == 0 {
+		t.Fatal("the deletion made while the syncer was down was applied; a " +
+			"reconciliation pass may have been added, so assert that instead")
+	}
+	t.Log("the key deleted while the syncer was down still exists on the target: " +
+		"deletions missed during downtime are never reconciled (F-081, F-085)")
+}
+
+// TestStartPanicsWithoutTableMapping records a crash. Start reads the stream
+// name as Mappings[0].Tables[0].SourceTable with no bounds check, while
+// config.loadSyncTasks synthesises exactly that shape — one mapping with an
+// empty Tables slice — whenever a task's config_json carries no mappings.
+//
+// A Redis task saved without table mappings therefore panics on startup, and
+// because cmd/sync launches each syncer in a bare goroutine the panic is not
+// recovered: the whole process dies, stopping replication for every other task
+// as well. "Tables" is also a meaningless notion for Redis, so this is an easy
+// configuration to arrive at.
+func TestStartPanicsWithoutTableMapping(t *testing.T) {
+	cfg := syncTask(t, "0")
+	cfg.Mappings = []config.DatabaseMapping{{Tables: []config.TableMapping{}}}
+
+	logger := logrus.New()
+	logger.SetLevel(logrus.PanicLevel)
+	syncer := NewRedisSyncer(cfg, logger)
+
+	done := make(chan interface{}, 1)
+	go func() {
+		defer func() { done <- recover() }()
+		ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+		defer cancel()
+		syncer.Start(ctx)
+	}()
+
+	select {
+	case recovered := <-done:
+		if recovered == nil {
+			t.Fatal("Start returned without panicking; a bounds check may have been " +
+				"added, so assert the graceful behaviour instead")
+		}
+		t.Logf("Start panicked as expected: %v", recovered)
+	case <-time.After(30 * time.Second):
+		t.Fatal("Start neither panicked nor returned")
+	}
+}
+
+// TestStreamEntriesReachTheTarget exercises F-083, which the feature inventory
+// lists as working. Two things in the stream path look wrong on reading, and
+// this checks whether either bites:
+//
+//   - watchStreamChanges calls XReadGroup with lastID, which starts at "0-0"
+//     and is only ever set to an id that was already processed. For a consumer
+//     group that means "give me my pending entries", never ">" for new ones.
+//   - processStreamMessage builds the target key name msg:<id> and then asks
+//     the *source* for that key's type. The name is invented for the target, so
+//     the source returns "none" and the message is rejected as an unsupported
+//     type before anything is written.
+func TestStreamEntriesReachTheTarget(t *testing.T) {
+	flush(t, 0)
+	src, tgt := client(t, harness.RedisSource, 0), client(t, harness.RedisTarget, 0)
+	ctx := context.Background()
+
+	const stream = "sync_stream"
+	if err := src.XAdd(ctx, &goredis.XAddArgs{
+		Stream: stream,
+		Values: map[string]interface{}{"user_id": "1", "name": "before"},
+	}).Err(); err != nil {
+		t.Fatalf("seed stream: %v", err)
+	}
+
+	startSyncer(t, syncTask(t, "0"))
+
+	// The initial full copy carries the stream key itself across, so the target
+	// has the data as a stream; that is not what the stream replication path is
+	// supposed to produce.
+	harness.Eventually(t, 30*time.Second, func() error {
+		if tgt.Exists(ctx, stream).Val() != 1 {
+			return fmt.Errorf("the initial copy has not landed")
+		}
+		return nil
+	})
+
+	if err := src.XAdd(ctx, &goredis.XAddArgs{
+		Stream: stream,
+		Values: map[string]interface{}{"user_id": "2", "name": "after"},
+	}).Err(); err != nil {
+		t.Fatalf("add entry: %v", err)
+	}
+
+	// processStreamMessage stores each entry under msg:<id> on the target.
+	// Nothing is ever written to the target, so this window is spent in full
+	// while the defect stands and exits immediately once it is fixed.
+	harness.Eventually(t, 5*time.Second, func() error {
+		keys, err := tgt.Keys(ctx, "msg:*").Result()
+		if err != nil {
+			return err
+		}
+		if len(keys) == 0 {
+			return fmt.Errorf("no msg:* key was written; the stream entry added " +
+				"after startup was never replicated (F-083)")
+		}
+		return nil
+	})
+}
+
+// TestStreamConsumerGroupNeverReceivesNewEntries isolates the first of the two
+// problems: whether the consumer group is delivered anything at all. If the
+// group's pending list stays empty while entries pile up in the stream, the
+// reader never asked for new messages.
+func TestStreamConsumerGroupNeverReceivesNewEntries(t *testing.T) {
+	flush(t, 0)
+	src := client(t, harness.RedisSource, 0)
+	ctx := context.Background()
+
+	const stream = "sync_stream"
+	if err := src.XAdd(ctx, &goredis.XAddArgs{
+		Stream: stream, Values: map[string]interface{}{"seed": "1"},
+	}).Err(); err != nil {
+		t.Fatalf("seed stream: %v", err)
+	}
+
+	startSyncer(t, syncTask(t, "0"))
+
+	// Wait for the group to exist rather than sleeping a fixed interval: the
+	// syncer creates it during startup, normally within a few hundred ms.
+	harness.Eventually(t, 5*time.Second, func() error {
+		groups, err := src.XInfoGroups(ctx, stream).Result()
+		if err != nil {
+			return fmt.Errorf("XInfoGroups: %w", err)
+		}
+		if len(groups) == 0 {
+			return fmt.Errorf("the consumer group has not been created yet")
+		}
+		return nil
+	})
+
+	for i := 0; i < 5; i++ {
+		if err := src.XAdd(ctx, &goredis.XAddArgs{
+			Stream: stream, Values: map[string]interface{}{"n": i},
+		}).Err(); err != nil {
+			t.Fatalf("add entry %d: %v", i, err)
+		}
+	}
+
+	// The group never advances while the defect stands, so this window is spent
+	// in full; it returns at once if delivery starts working.
+	harness.WaitFor(2*time.Second, func() error {
+		groups, err := src.XInfoGroups(ctx, stream).Result()
+		if err != nil || len(groups) == 0 {
+			return fmt.Errorf("group not readable")
+		}
+		if groups[0].LastDeliveredID == "0-0" {
+			return fmt.Errorf("still at 0-0")
+		}
+		return nil
+	})
+
+	groups, err := src.XInfoGroups(ctx, stream).Result()
+	if err != nil {
+		t.Fatalf("XInfoGroups: %v", err)
+	}
+	if len(groups) == 0 {
+		t.Fatal("the consumer group was never created")
+	}
+	g := groups[0]
+	t.Logf("group %q: pending=%d last-delivered=%s entries-read=%d",
+		g.Name, g.Pending, g.LastDeliveredID, g.EntriesRead)
+
+	if g.LastDeliveredID != "0-0" {
+		t.Skipf("the group has advanced to %s, so delivery is working after all",
+			g.LastDeliveredID)
+	}
+	t.Errorf("the consumer group is still at last-delivered %s after six entries "+
+		"were added: XReadGroup is never called with \">\", so new entries are "+
+		"never delivered (F-083)", g.LastDeliveredID)
+}

--- a/pkg/syncer/redis/position_test.go
+++ b/pkg/syncer/redis/position_test.go
@@ -1,0 +1,70 @@
+package redis
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+)
+
+func newSyncer(t *testing.T, positionPath string) *RedisSyncer {
+	t.Helper()
+
+	logger := logrus.New()
+	logger.SetLevel(logrus.PanicLevel)
+	return &RedisSyncer{logger: logger, positionPath: positionPath}
+}
+
+func TestStreamPositionRoundTrip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "state", "redis.pos")
+	s := newSyncer(t, path)
+
+	s.saveStreamPosition("1692600000000-0")
+
+	if got := s.loadStreamPosition(); got != "1692600000000-0" {
+		t.Errorf("loadStreamPosition = %q, want the saved id", got)
+	}
+}
+
+func TestSaveStreamPositionCreatesDirectory(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "a", "b", "redis.pos")
+	s := newSyncer(t, path)
+
+	s.saveStreamPosition("1-1")
+
+	if _, err := os.Stat(path); err != nil {
+		t.Errorf("the position file was not written: %v", err)
+	}
+}
+
+func TestLoadStreamPositionTrimsWhitespace(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "redis.pos")
+	if err := os.WriteFile(path, []byte("  5-5\n"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	s := newSyncer(t, path)
+
+	if got := s.loadStreamPosition(); got != "5-5" {
+		t.Errorf("loadStreamPosition = %q, want %q", got, "5-5")
+	}
+}
+
+func TestStreamPositionWithoutPath(t *testing.T) {
+	s := newSyncer(t, "")
+
+	// With no configured path the store is a no-op in both directions, so a
+	// task that omits redis_position_path silently keeps no stream offset.
+	s.saveStreamPosition("1-1")
+	if got := s.loadStreamPosition(); got != "" {
+		t.Errorf("loadStreamPosition = %q, want empty", got)
+	}
+}
+
+func TestLoadStreamPositionMissingFile(t *testing.T) {
+	s := newSyncer(t, filepath.Join(t.TempDir(), "absent.pos"))
+
+	if got := s.loadStreamPosition(); got != "" {
+		t.Errorf("loadStreamPosition = %q, want empty", got)
+	}
+}

--- a/pkg/syncer/security/security_test.go
+++ b/pkg/syncer/security/security_test.go
@@ -1,0 +1,354 @@
+package security
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"encoding/base64"
+	"strings"
+	"testing"
+
+	"github.com/retail-ai-inc/sync/pkg/config"
+	"go.mongodb.org/mongo-driver/bson"
+)
+
+func enabled(fields ...FieldSecurityConfig) TableSecurity {
+	return TableSecurity{SecurityEnabled: true, FieldSecurity: fields}
+}
+
+// decrypt mirrors encryptAES using the same package-level key, so the tests can
+// assert that ciphertext really carries the plaintext.
+func decrypt(t *testing.T, encoded string) string {
+	t.Helper()
+
+	raw, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		t.Fatalf("ciphertext is not base64: %v", err)
+	}
+	block, err := aes.NewCipher(encryptionKey)
+	if err != nil {
+		t.Fatalf("new cipher: %v", err)
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		t.Fatalf("new gcm: %v", err)
+	}
+	if len(raw) < gcm.NonceSize() {
+		t.Fatalf("ciphertext shorter than nonce: %d bytes", len(raw))
+	}
+	plain, err := gcm.Open(nil, raw[:gcm.NonceSize()], raw[gcm.NonceSize():], nil)
+	if err != nil {
+		t.Fatalf("decrypt: %v", err)
+	}
+	return string(plain)
+}
+
+func TestProcessValuePassesThroughWhenDisabled(t *testing.T) {
+	cfg := TableSecurity{
+		SecurityEnabled: false,
+		FieldSecurity:   []FieldSecurityConfig{{Field: "email", SecurityType: "masked"}},
+	}
+
+	if got := ProcessValue("john@example.com", "email", cfg); got != "john@example.com" {
+		t.Errorf("ProcessValue with security disabled = %v, want the original value", got)
+	}
+}
+
+func TestProcessValuePassesThroughUnconfiguredField(t *testing.T) {
+	cfg := enabled(FieldSecurityConfig{Field: "email", SecurityType: "masked"})
+
+	if got := ProcessValue("Tokyo", "city", cfg); got != "Tokyo" {
+		t.Errorf("ProcessValue for an unconfigured field = %v, want the original value", got)
+	}
+}
+
+func TestProcessValueMasked(t *testing.T) {
+	cfg := enabled(FieldSecurityConfig{Field: "email", SecurityType: "masked"})
+
+	tests := []struct {
+		name  string
+		value interface{}
+		want  interface{}
+	}{
+		// Strings are replaced with one asterisk per byte, so the length leaks.
+		{"string", "john@example.com", strings.Repeat("*", len("john@example.com"))},
+		{"empty string", "", ""},
+		// Everything else collapses to a fixed literal, changing the value's type.
+		{"int", 12345, "****"},
+		{"bool", true, "****"},
+		{"nil", nil, "****"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ProcessValue(tt.value, "email", cfg); got != tt.want {
+				t.Errorf("ProcessValue(%#v) = %#v, want %#v", tt.value, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestProcessValueMaskedCountsBytesNotRunes records that masking uses byte
+// length, so a multibyte value is replaced by more asterisks than it has
+// characters. Harmless on its own, but it means the mask leaks the encoded
+// size rather than a uniform placeholder.
+func TestProcessValueMaskedCountsBytesNotRunes(t *testing.T) {
+	cfg := enabled(FieldSecurityConfig{Field: "name", SecurityType: "masked"})
+
+	got := ProcessValue("日本語", "name", cfg)
+
+	if got == strings.Repeat("*", 3) {
+		t.Fatalf("masking now counts runes; update this test to assert the new behaviour")
+	}
+	if want := strings.Repeat("*", 9); got != want {
+		t.Errorf("ProcessValue(%q) = %v, want %q (9 bytes)", "日本語", got, want)
+	}
+}
+
+func TestProcessValueEncrypted(t *testing.T) {
+	cfg := enabled(FieldSecurityConfig{Field: "phone", SecurityType: "encrypted"})
+
+	t.Run("string", func(t *testing.T) {
+		got, ok := ProcessValue("090-1234-5678", "phone", cfg).(string)
+		if !ok {
+			t.Fatalf("encrypted value is not a string")
+		}
+		if plain := decrypt(t, got); plain != "090-1234-5678" {
+			t.Errorf("decrypted to %q, want %q", plain, "090-1234-5678")
+		}
+	})
+
+	t.Run("byte slice", func(t *testing.T) {
+		got, ok := ProcessValue([]byte("secret"), "phone", cfg).(string)
+		if !ok {
+			t.Fatalf("encrypted value is not a string")
+		}
+		if plain := decrypt(t, got); plain != "secret" {
+			t.Errorf("decrypted to %q, want %q", plain, "secret")
+		}
+	})
+
+	t.Run("other types go through fmt", func(t *testing.T) {
+		got, ok := ProcessValue(42, "phone", cfg).(string)
+		if !ok {
+			t.Fatalf("encrypted value is not a string")
+		}
+		if plain := decrypt(t, got); plain != "42" {
+			t.Errorf("decrypted to %q, want %q", plain, "42")
+		}
+	})
+}
+
+// TestProcessValueEncryptedIsNonDeterministic records a property that matters
+// for replication: AES-GCM uses a fresh random nonce, so the same source value
+// encrypts to different ciphertext on every call. Consequences:
+//
+//   - re-running an initial sync rewrites every encrypted field even when the
+//     source has not changed
+//   - source and target can never be compared on encrypted fields, so the
+//     row-count and checksum verification planned for the DR work cannot cover
+//     them
+func TestProcessValueEncryptedIsNonDeterministic(t *testing.T) {
+	cfg := enabled(FieldSecurityConfig{Field: "phone", SecurityType: "encrypted"})
+
+	first := ProcessValue("090-1234-5678", "phone", cfg)
+	second := ProcessValue("090-1234-5678", "phone", cfg)
+
+	if first == second {
+		t.Errorf("encryption became deterministic (%v); if that was intentional, "+
+			"update this test and the consistency-check design", first)
+	}
+	if decrypt(t, first.(string)) != decrypt(t, second.(string)) {
+		t.Error("the two ciphertexts do not decrypt to the same plaintext")
+	}
+}
+
+// TestProcessValueUnknownSecurityTypeReturnsNil records a defect that destroys
+// data. ProcessValue declares `var processed interface{}`, switches on the
+// security type, and returns `processed` unconditionally — so any type outside
+// {masked, encrypted} returns nil and the field is written to the target as
+// NULL. The comparison is case-sensitive, so "Masked" is enough to trigger it,
+// and FindTableSecurityFromMappings accepts whatever string the UI stored as
+// long as it is non-empty.
+func TestProcessValueUnknownSecurityTypeReturnsNil(t *testing.T) {
+	for _, secType := range []string{"Masked", "MASKED", "hashed", "redacted", "unknown"} {
+		t.Run(secType, func(t *testing.T) {
+			cfg := enabled(FieldSecurityConfig{Field: "email", SecurityType: secType})
+
+			got := ProcessValue("john@example.com", "email", cfg)
+
+			if got != nil {
+				t.Errorf("ProcessValue with securityType %q = %#v; unknown types no "+
+					"longer null the value, so assert the new behaviour instead", secType, got)
+			}
+		})
+	}
+}
+
+func TestProcessValueNestedObject(t *testing.T) {
+	cfg := enabled(FieldSecurityConfig{Field: "profile.email", SecurityType: "masked"})
+
+	value := map[string]interface{}{
+		"email": "john@example.com",
+		"city":  "Tokyo",
+	}
+
+	got, ok := ProcessValue(value, "profile", cfg).(map[string]interface{})
+	if !ok {
+		t.Fatalf("nested processing did not return a map")
+	}
+	if want := strings.Repeat("*", len("john@example.com")); got["email"] != want {
+		t.Errorf("profile.email = %v, want %q", got["email"], want)
+	}
+	if got["city"] != "Tokyo" {
+		t.Errorf("profile.city = %v, want it untouched", got["city"])
+	}
+	// The input map must not be mutated; the syncers reuse the source document.
+	if value["email"] != "john@example.com" {
+		t.Errorf("input map was mutated: %v", value["email"])
+	}
+}
+
+func TestProcessValueNestedBSON(t *testing.T) {
+	cfg := enabled(FieldSecurityConfig{Field: "profile.email", SecurityType: "masked"})
+
+	got, ok := ProcessValue(bson.M{"email": "a@b.com"}, "profile", cfg).(map[string]interface{})
+	if !ok {
+		t.Fatalf("bson.M was not handled as a nested object")
+	}
+	if want := strings.Repeat("*", len("a@b.com")); got["email"] != want {
+		t.Errorf("profile.email = %v, want %q", got["email"], want)
+	}
+}
+
+// TestProcessValueNestedObjectStopsAtOneLevel records that only a single level
+// of nesting is honoured. processNestedObject strips the parent prefix and then
+// looks the remainder up as a literal map key, so "profile.contact.phone"
+// searches for a key named "contact.phone" and finds nothing. Deeply nested PII
+// is therefore silently left in the clear.
+func TestProcessValueNestedObjectStopsAtOneLevel(t *testing.T) {
+	cfg := enabled(FieldSecurityConfig{Field: "profile.contact.phone", SecurityType: "masked"})
+
+	value := map[string]interface{}{
+		"contact": map[string]interface{}{"phone": "090-1234-5678"},
+	}
+
+	got, ok := ProcessValue(value, "profile", cfg).(map[string]interface{})
+	if !ok {
+		t.Fatalf("nested processing did not return a map")
+	}
+	contact, ok := got["contact"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("contact is not a map: %#v", got["contact"])
+	}
+	if contact["phone"] != "090-1234-5678" {
+		t.Errorf("profile.contact.phone = %v; two-level nesting now works, so "+
+			"assert the masked value instead", contact["phone"])
+	}
+}
+
+// TestProcessNestedFieldValueNeverEngages records that this exported helper
+// cannot do anything when reached through ProcessValue. ProcessValue only
+// delegates here once the value has failed both the map[string]interface{} and
+// bson.M checks, and the first thing this function does is require one of those
+// two types — so it always takes the "not object type" path and returns the
+// value untouched. processNestedObjectValue, its only caller, is unreachable
+// for the same reason.
+func TestProcessNestedFieldValueNeverEngages(t *testing.T) {
+	cfg := enabled(FieldSecurityConfig{Field: "profile.email", SecurityType: "masked"})
+
+	// A non-object value: the only kind that reaches this function.
+	if got := ProcessNestedFieldValue("john@example.com", "profile.email", cfg); got != "john@example.com" {
+		t.Errorf("ProcessNestedFieldValue = %v; it now processes scalars, so "+
+			"assert the new behaviour instead", got)
+	}
+}
+
+func TestFindTableSecurityFromMappings(t *testing.T) {
+	mappings := []config.DatabaseMapping{{
+		Tables: []config.TableMapping{{
+			SourceTable:     "users",
+			TargetTable:     "users_copy",
+			SecurityEnabled: true,
+			FieldSecurity: []interface{}{
+				map[string]interface{}{"field": "email", "securityType": "masked"},
+				map[string]interface{}{"field": "profile.phone", "securityType": "encrypted"},
+			},
+		}},
+	}}
+
+	for _, name := range []string{"users", "users_copy"} {
+		t.Run("matches "+name, func(t *testing.T) {
+			got := FindTableSecurityFromMappings(name, mappings)
+
+			if !got.SecurityEnabled {
+				t.Error("SecurityEnabled = false, want true")
+			}
+			if len(got.FieldSecurity) != 2 {
+				t.Fatalf("FieldSecurity has %d entries, want 2", len(got.FieldSecurity))
+			}
+			if got.FieldSecurity[0] != (FieldSecurityConfig{Field: "email", SecurityType: "masked"}) {
+				t.Errorf("FieldSecurity[0] = %+v", got.FieldSecurity[0])
+			}
+			if got.FieldSecurity[1] != (FieldSecurityConfig{Field: "profile.phone", SecurityType: "encrypted"}) {
+				t.Errorf("FieldSecurity[1] = %+v", got.FieldSecurity[1])
+			}
+		})
+	}
+}
+
+func TestFindTableSecurityFromMappingsNotFound(t *testing.T) {
+	mappings := []config.DatabaseMapping{{
+		Tables: []config.TableMapping{{SourceTable: "users", TargetTable: "users", SecurityEnabled: true}},
+	}}
+
+	got := FindTableSecurityFromMappings("orders", mappings)
+
+	// A miss must yield a disabled config, never a partially filled one.
+	if got.SecurityEnabled || len(got.FieldSecurity) != 0 {
+		t.Errorf("miss returned %+v, want the zero value", got)
+	}
+	if got := FindTableSecurityFromMappings("users", nil); got.SecurityEnabled {
+		t.Errorf("nil mappings returned %+v, want the zero value", got)
+	}
+}
+
+func TestFindTableSecurityFromMappingsSkipsIncompleteEntries(t *testing.T) {
+	mappings := []config.DatabaseMapping{{
+		Tables: []config.TableMapping{{
+			SourceTable:     "users",
+			TargetTable:     "users",
+			SecurityEnabled: true,
+			FieldSecurity: []interface{}{
+				map[string]interface{}{"field": "email", "securityType": "masked"},
+				map[string]interface{}{"field": "", "securityType": "masked"}, // no field name
+				map[string]interface{}{"field": "phone", "securityType": ""},  // no type
+				map[string]interface{}{"field": "city"},                       // type missing
+				"not-a-map",                                                   // wrong shape entirely
+			},
+		}},
+	}}
+
+	got := FindTableSecurityFromMappings("users", mappings)
+
+	// Only the complete entry survives; the rest are dropped without a trace in
+	// the returned config, which is why a mistyped UI entry looks like it worked.
+	if len(got.FieldSecurity) != 1 {
+		t.Fatalf("FieldSecurity has %d entries, want 1: %+v", len(got.FieldSecurity), got.FieldSecurity)
+	}
+	if got.FieldSecurity[0].Field != "email" {
+		t.Errorf("surviving entry = %+v, want the email rule", got.FieldSecurity[0])
+	}
+}
+
+// TestEncryptionKeyIsHardcoded records F-101: the AES-256 key is a literal in
+// the source, identical in every deployment, and committed to a public
+// repository. Any encrypted target data is readable by anyone with the source.
+func TestEncryptionKeyIsHardcoded(t *testing.T) {
+	if string(encryptionKey) != "0123456789abcdef0123456789abcdef" {
+		t.Errorf("the hardcoded key changed to %q; if key management landed, "+
+			"replace this test with one covering the new source", encryptionKey)
+	}
+	if len(encryptionKey) != 32 {
+		t.Errorf("key length = %d, want 32 for AES-256", len(encryptionKey))
+	}
+}

--- a/pkg/utils/coverage_gaps_test.go
+++ b/pkg/utils/coverage_gaps_test.go
@@ -1,0 +1,204 @@
+package utils
+
+import (
+	"database/sql"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	_ "github.com/mattn/go-sqlite3"
+	"github.com/sirupsen/logrus"
+	"go.mongodb.org/mongo-driver/bson"
+)
+
+func TestUnzipDistFileDependsOnAnExternalBinary(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("PATH", dir) // an empty PATH: no unzip anywhere
+
+	err := UnzipDistFile(filepath.Join(dir, "x.zip"), filepath.Join(dir, "out"))
+	if err == nil {
+		t.Fatal("UnzipDistFile() = nil without unzip on PATH — it appears to use archive/zip now")
+	}
+	if !strings.Contains(err.Error(), "system unzip command") {
+		t.Fatalf("err = %v — the external dependency appears to be gone", err)
+	}
+}
+
+func TestInitDBPathRespectsAnExistingEnvironmentVariable(t *testing.T) {
+	t.Setenv("SYNC_DB_PATH", "/somewhere/else/sync.db")
+
+	initDBPath()
+
+	if got := os.Getenv("SYNC_DB_PATH"); got != "/somewhere/else/sync.db" {
+		t.Errorf("SYNC_DB_PATH = %q, want the pre-set value to be left alone", got)
+	}
+}
+
+// When SYNC_DB_PATH is unset, the fallback is derived from runtime.Caller,
+// which yields the path of this source file **on the machine that compiled
+// the binary**. In a container built elsewhere that directory does not exist,
+// and OpenSQLiteDB then MkdirAll's it and creates an empty database there — so
+// a deployment that forgets SYNC_DB_PATH starts with no tasks rather than
+// failing loudly.
+func TestTheDBPathFallbackIsABuildTimeSourcePath(t *testing.T) {
+	t.Setenv("SYNC_DB_PATH", "")
+
+	initDBPath()
+
+	got := os.Getenv("SYNC_DB_PATH")
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Skip("runtime.Caller is unavailable")
+	}
+	want := filepath.Join(filepath.Dir(thisFile), "..", "..", "sync.db")
+
+	if got != want {
+		t.Fatalf("SYNC_DB_PATH = %q, want the build-time source path %q — the fallback appears to have changed; assert the new one instead", got, want)
+	}
+	if !filepath.IsAbs(got) {
+		t.Errorf("the fallback %q is not absolute", got)
+	}
+}
+
+func TestGetJSTTimeRangeReturnsMidnightBoundaries(t *testing.T) {
+	start, end, err := GetJSTTimeRange(-1, 0)
+	if err != nil {
+		t.Fatalf("GetJSTTimeRange: %v", err)
+	}
+
+	for _, ts := range []time.Time{start, end} {
+		if ts.Hour() != 0 || ts.Minute() != 0 || ts.Second() != 0 || ts.Nanosecond() != 0 {
+			t.Errorf("%v is not midnight", ts)
+		}
+		if name, offset := ts.Zone(); offset != 9*60*60 {
+			t.Errorf("%v is in zone %s (offset %d), want JST (+32400)", ts, name, offset)
+		}
+	}
+	if got := end.Sub(start); got != 24*time.Hour {
+		t.Errorf("end - start = %v, want 24h", got)
+	}
+}
+
+func TestGetJSTTimeRangeSpansMultipleDays(t *testing.T) {
+	start, end, err := GetJSTTimeRange(-7, 0)
+	if err != nil {
+		t.Fatalf("GetJSTTimeRange: %v", err)
+	}
+	if got := end.Sub(start); got != 7*24*time.Hour {
+		t.Errorf("end - start = %v, want 168h", got)
+	}
+}
+
+func TestGetUTCTimeRangeIsTheJSTRangeShifted(t *testing.T) {
+	startJST, endJST, err := GetJSTTimeRange(-1, 0)
+	if err != nil {
+		t.Fatalf("GetJSTTimeRange: %v", err)
+	}
+	startUTC, endUTC, err := GetUTCTimeRange(-1, 0)
+	if err != nil {
+		t.Fatalf("GetUTCTimeRange: %v", err)
+	}
+
+	if !startUTC.Equal(startJST) || !endUTC.Equal(endJST) {
+		t.Errorf("UTC range (%v, %v) is not the same instant as the JST range (%v, %v)",
+			startUTC, endUTC, startJST, endJST)
+	}
+	// JST midnight is 15:00 the previous day in UTC.
+	if startUTC.UTC().Hour() != 15 {
+		t.Errorf("start in UTC is %v, want 15:00 the previous day", startUTC.UTC())
+	}
+	if name, offset := startUTC.Zone(); offset != 0 {
+		t.Errorf("start zone = %s (offset %d), want UTC", name, offset)
+	}
+}
+
+func TestNewQueryCounterSuppliesADefaultLogger(t *testing.T) {
+	if qc := NewQueryCounter(nil); qc.logger == nil {
+		t.Error("NewQueryCounter(nil) left the logger nil")
+	}
+
+	given := logrus.New()
+	if qc := NewQueryCounter(given); qc.logger != given {
+		t.Error("NewQueryCounter replaced the supplied logger")
+	}
+}
+func TestCheckSQLConnection(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "probe.db")
+	db, err := sql.Open("sqlite3", path)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+
+	if err := CheckSQLConnection(t.Context(), db); err != nil {
+		t.Errorf("CheckSQLConnection on an open database = %v", err)
+	}
+
+	if err := db.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	if err := CheckSQLConnection(t.Context(), db); err == nil {
+		t.Error("CheckSQLConnection on a closed database = nil, want an error")
+	}
+}
+
+func TestReopenSQLConnection(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "reopen.db")
+
+	db, err := ReopenSQLConnection(t.Context(), quietLogger(), path, "sqlite3")
+	if err != nil {
+		t.Fatalf("ReopenSQLConnection: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	if err := db.PingContext(t.Context()); err != nil {
+		t.Errorf("the returned handle does not ping: %v", err)
+	}
+}
+
+// ReopenSQLConnection routes every failure through Retry(5, 2s, 2.0) with no
+// error classification, so a permanent misconfiguration — an unregistered
+// driver, a malformed DSN — is retried five times over 62 seconds (2+4+8+16+32)
+// before the error surfaces. This test only proves the classification is
+// absent; the timing is covered by TestRetrySleepsAfterTheFinalFailure.
+func TestReopenSQLConnectionDoesNotClassifyErrors(t *testing.T) {
+	attempts := 0
+	err := Retry(2, time.Millisecond, 1.0, func() error {
+		attempts++
+		_, openErr := sql.Open("no-such-driver", "whatever")
+		return openErr
+	})
+
+	if err == nil {
+		t.Fatal("an unregistered driver did not produce an error")
+	}
+	if attempts != 2 {
+		t.Fatalf("a permanent error was attempted %d times, want 2 — Retry appears to classify errors now", attempts)
+	}
+}
+
+// The existing formatFilterCondition table does not reach $gt, or the
+// non-time branches of $gte and $lte. These pin them.
+func TestFormatFilterConditionRemainingOperators(t *testing.T) {
+	qc := NewQueryCounter(nil)
+
+	tests := []struct {
+		name  string
+		value interface{}
+		want  string
+	}{
+		{"$gt", bson.M{"$gt": 10}, "age: {$gt: 10}"},
+		{"$gte with a plain value", bson.M{"$gte": 1}, "age: {$gte: 1}"},
+		{"$lte with a plain value", bson.M{"$lte": 1}, "age: {$lte: 1}"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := qc.formatFilterCondition("age", tc.value); got != tc.want {
+				t.Errorf("formatFilterCondition(age, %#v) = %q, want %q", tc.value, got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/utils/db_utils_test.go
+++ b/pkg/utils/db_utils_test.go
@@ -1,0 +1,200 @@
+package utils
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+// quietLogger returns a logger that discards output, so retry tests do not
+// flood the test log.
+func quietLogger() *logrus.Logger {
+	l := logrus.New()
+	l.SetOutput(io.Discard)
+	return l
+}
+
+func TestIsConnectionError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"connection refused", errors.New("dial tcp 127.0.0.1:3306: connect: connection refused"), true},
+		{"broken pipe", errors.New("write tcp: broken pipe"), true},
+		{"reset by peer", errors.New("read tcp: connection reset by peer"), true},
+		{"i/o timeout", errors.New("read tcp: i/o timeout"), true},
+		{"EOF", io.EOF, true},
+		{"network unreachable", errors.New("network is unreachable"), true},
+		{"syntax error", errors.New("syntax error near 'SELCT'"), false},
+		{"duplicate key", errors.New("Error 1062: Duplicate entry 'a' for key 'PRIMARY'"), false},
+		{"permission denied", errors.New("Access denied for user 'root'"), false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IsConnectionError(tc.err); got != tc.want {
+				t.Errorf("IsConnectionError(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
+// The classifier is a substring scan over the error text, so errors that are
+// permanent get retried. "connection" matches a malformed DSN, "EOF" matches a
+// truncated JSON document — neither is transient, and both cost three attempts
+// and seven seconds of backoff before the original error is returned.
+func TestPermanentErrorsAreClassifiedAsTransient(t *testing.T) {
+	permanent := []error{
+		errors.New(`invalid connection string: missing "@"`),
+		errors.New("unexpected EOF while parsing config JSON"),
+		errors.New("error parsing uri: scheme must be mongodb:// — bad connection uri"),
+		errors.New("unexpected EOF"),
+	}
+
+	for _, err := range permanent {
+		if !IsConnectionError(err) {
+			t.Fatalf("IsConnectionError(%q) = false — the classifier appears to have been narrowed; assert the new classification instead", err)
+		}
+	}
+}
+
+// Conversely, several errors that really are transient do not match any of the
+// substrings, so they are returned to the caller on the first attempt with no
+// retry at all.
+func TestTransientErrorsAreClassifiedAsPermanent(t *testing.T) {
+	transient := []error{
+		errors.New("server selection error: context deadline exceeded"),
+		errors.New("no reachable servers"),
+		errors.New("topology is closed"),
+		errors.New("database is locked"),
+		errors.New("Error 1213: Deadlock found when trying to get lock"),
+	}
+
+	for _, err := range transient {
+		if IsConnectionError(err) {
+			t.Fatalf("IsConnectionError(%q) = true — the classifier appears to have been widened; assert the new classification instead", err)
+		}
+	}
+}
+
+func TestRetryDBOperationSucceedsWithoutRetrying(t *testing.T) {
+	calls := 0
+	err := RetryDBOperation(context.Background(), quietLogger(), "op", func() error {
+		calls++
+		return nil
+	})
+
+	if err != nil {
+		t.Errorf("err = %v, want nil", err)
+	}
+	if calls != 1 {
+		t.Errorf("fn called %d times, want 1", calls)
+	}
+}
+
+func TestRetryDBOperationDoesNotRetryPermanentErrors(t *testing.T) {
+	want := errors.New("syntax error")
+	calls := 0
+
+	start := time.Now()
+	err := RetryDBOperation(context.Background(), quietLogger(), "op", func() error {
+		calls++
+		return want
+	})
+
+	if !errors.Is(err, want) {
+		t.Errorf("err = %v, want %v", err, want)
+	}
+	if calls != 1 {
+		t.Errorf("fn called %d times, want 1", calls)
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Errorf("took %v — a permanent error should not sleep", elapsed)
+	}
+}
+
+func TestRetryDBOperationRecoversOnASecondAttempt(t *testing.T) {
+	calls := 0
+	err := RetryDBOperation(context.Background(), quietLogger(), "op", func() error {
+		calls++
+		if calls == 1 {
+			return errors.New("connection refused")
+		}
+		return nil
+	})
+
+	if err != nil {
+		t.Errorf("err = %v, want nil", err)
+	}
+	if calls != 2 {
+		t.Errorf("fn called %d times, want 2", calls)
+	}
+}
+
+func TestRetryDBOperationHonoursContextCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	calls := 0
+	err := RetryDBOperation(ctx, quietLogger(), "op", func() error {
+		calls++
+		return errors.New("connection refused")
+	})
+
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("err = %v, want context.Canceled", err)
+	}
+	if calls != 1 {
+		t.Errorf("fn called %d times, want 1 before the cancellation was noticed", calls)
+	}
+}
+
+func TestRetryMongoOperationDelegatesToRetryDBOperation(t *testing.T) {
+	calls := 0
+	err := RetryMongoOperation(context.Background(), quietLogger(), "op", func() error {
+		calls++
+		return errors.New("syntax error")
+	})
+
+	if err == nil {
+		t.Error("err = nil, want the permanent error")
+	}
+	if calls != 1 {
+		t.Errorf("fn called %d times, want 1", calls)
+	}
+}
+
+// The backoff sleep runs after every failed attempt including the last, so a
+// call that exhausts its three attempts spends 1s + 2s + 4s = 7s in
+// time.After. The final four seconds buy nothing: the loop is over and the
+// original error is returned regardless. During a failover — exactly when
+// every operation is failing — each retried call blocks its goroutine for
+// seven seconds instead of three.
+func TestTheFinalBackoffSleepIsWasted(t *testing.T) {
+	calls := 0
+	start := time.Now()
+
+	err := RetryDBOperation(context.Background(), quietLogger(), "op", func() error {
+		calls++
+		return fmt.Errorf("attempt %d: connection refused", calls)
+	})
+
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("err = nil, want the last connection error")
+	}
+	if calls != 3 {
+		t.Errorf("fn called %d times, want 3", calls)
+	}
+	if elapsed < 6500*time.Millisecond {
+		t.Fatalf("took %v, expected ~7s — the trailing sleep appears to have been removed; assert the new timing instead", elapsed)
+	}
+}

--- a/pkg/utils/monitor_integration_test.go
+++ b/pkg/utils/monitor_integration_test.go
@@ -1,0 +1,592 @@
+//go:build integration
+
+package utils
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"testing"
+	"time"
+
+	_ "github.com/go-sql-driver/mysql"
+	goredis "github.com/redis/go-redis/v9"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+
+	"github.com/retail-ai-inc/sync/pkg/config"
+	"github.com/retail-ai-inc/sync/test/harness"
+)
+
+const (
+	sourceDB = "source_db"
+	targetDB = "target_db"
+
+	// The redis syncer package's integration tests own db 0 and db 1 and
+	// flush them. go test runs packages in parallel, so the monitor tests
+	// use their own indices to stay out of the way.
+	monitorRedisDB = 9
+)
+
+func mysqlDSN(t *testing.T, endpoint, database string) string {
+	t.Helper()
+
+	host, port := harness.SplitHostPort(t, endpoint)
+	return config.BuildDSNByType("mysql", map[string]string{
+		"user": "root", "password": "root", "host": host, "port": port, "database": database,
+	})
+}
+
+func openMySQL(t *testing.T, endpoint, database string) *sql.DB {
+	t.Helper()
+
+	db, err := sql.Open("mysql", mysqlDSN(t, endpoint, database))
+	if err != nil {
+		t.Fatalf("open %s: %v", endpoint, err)
+	}
+	if err := db.Ping(); err != nil {
+		t.Fatalf("ping %s: %v", endpoint, err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	return db
+}
+
+func openMongo(t *testing.T, endpoint string) *mongo.Client {
+	t.Helper()
+
+	uri := "mongodb://" + endpoint + "/?directConnection=true"
+	client, err := mongo.Connect(t.Context(), options.Client().ApplyURI(uri))
+	if err != nil {
+		t.Fatalf("connect %s: %v", endpoint, err)
+	}
+	if err := client.Ping(t.Context(), nil); err != nil {
+		t.Fatalf("ping %s: %v", endpoint, err)
+	}
+	t.Cleanup(func() { _ = client.Disconnect(context.Background()) })
+	return client
+}
+
+func openRedis(t *testing.T, endpoint string, dbIndex int) *goredis.Client {
+	t.Helper()
+
+	c := goredis.NewClient(&goredis.Options{Addr: endpoint, DB: dbIndex})
+	if err := c.Ping(t.Context()).Err(); err != nil {
+		t.Fatalf("ping %s: %v", endpoint, err)
+	}
+	t.Cleanup(func() { _ = c.Close() })
+	return c
+}
+
+// monitoringRow is one monitoring_log entry.
+type monitoringRow struct {
+	TaskID          int
+	DBType          string
+	SrcDB, SrcTable string
+	SrcCount        int64
+	TgtDB, TgtTable string
+	TgtCount        int64
+	Action          string
+}
+
+func readMonitoringLog(t *testing.T, conn *sql.DB) []monitoringRow {
+	t.Helper()
+
+	rows, err := conn.Query(`
+		SELECT sync_task_id, db_type, src_db, src_table, src_row_count,
+		       tgt_db, tgt_table, tgt_row_count, monitor_action
+		FROM monitoring_log ORDER BY id`)
+	if err != nil {
+		t.Fatalf("query monitoring_log: %v", err)
+	}
+	defer rows.Close()
+
+	var out []monitoringRow
+	for rows.Next() {
+		var r monitoringRow
+		if err := rows.Scan(&r.TaskID, &r.DBType, &r.SrcDB, &r.SrcTable, &r.SrcCount,
+			&r.TgtDB, &r.TgtTable, &r.TgtCount, &r.Action); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		out = append(out, r)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate: %v", err)
+	}
+	return out
+}
+
+// ------------------------------------------------------------------- MySQL
+
+func TestCountAndLogMySQLRecordsBothSides(t *testing.T) {
+	conn := useMonitoringDB(t)
+
+	table := harness.UniqueName("mon")
+	src := openMySQL(t, harness.MySQLSource, sourceDB)
+	tgt := openMySQL(t, harness.MySQLTarget, targetDB)
+
+	ddl := fmt.Sprintf("CREATE TABLE %s (id INT PRIMARY KEY)", table)
+	if _, err := src.Exec(ddl); err != nil {
+		t.Fatalf("create source table: %v", err)
+	}
+	if _, err := tgt.Exec(ddl); err != nil {
+		t.Fatalf("create target table: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = src.Exec("DROP TABLE " + table)
+		_, _ = tgt.Exec("DROP TABLE " + table)
+	})
+
+	// Three rows at the source, two at the target: a divergence the monitor
+	// is supposed to make visible.
+	if _, err := src.Exec(fmt.Sprintf("INSERT INTO %s (id) VALUES (1),(2),(3)", table)); err != nil {
+		t.Fatalf("seed source: %v", err)
+	}
+	if _, err := tgt.Exec(fmt.Sprintf("INSERT INTO %s (id) VALUES (1),(2)", table)); err != nil {
+		t.Fatalf("seed target: %v", err)
+	}
+
+	sc := config.SyncConfig{
+		ID:               101,
+		Enable:           true,
+		Type:             "mysql",
+		SourceConnection: mysqlDSN(t, harness.MySQLSource, sourceDB),
+		TargetConnection: mysqlDSN(t, harness.MySQLTarget, targetDB),
+		Mappings: []config.DatabaseMapping{{
+			Tables: []config.TableMapping{{SourceTable: table, TargetTable: table}},
+		}},
+	}
+
+	countAndLogTables(t.Context(), sc, quietLogger())
+
+	got := readMonitoringLog(t, conn)
+	if len(got) != 1 {
+		t.Fatalf("monitoring_log holds %d rows, want 1: %+v", len(got), got)
+	}
+	r := got[0]
+	if r.TaskID != 101 || r.DBType != "MYSQL" || r.Action != "row_count_minutely" {
+		t.Errorf("row = %+v", r)
+	}
+	if r.SrcDB != sourceDB || r.TgtDB != targetDB {
+		t.Errorf("databases = %q -> %q, want %q -> %q", r.SrcDB, r.TgtDB, sourceDB, targetDB)
+	}
+	if r.SrcTable != table || r.TgtTable != table {
+		t.Errorf("tables = %q -> %q, want %q", r.SrcTable, r.TgtTable, table)
+	}
+	if r.SrcCount != 3 || r.TgtCount != 2 {
+		t.Errorf("counts = %d -> %d, want 3 -> 2", r.SrcCount, r.TgtCount)
+	}
+}
+
+// A table named in the configuration but absent from the database yields the
+// -1 sentinel, which is stored as though it were a row count. A typo in a task
+// definition produces monitoring rows that read as "minus one row" rather than
+// an error, and nothing anywhere reports the misconfiguration.
+func TestAMissingTableIsRecordedAsMinusOne(t *testing.T) {
+	conn := useMonitoringDB(t)
+
+	sc := config.SyncConfig{
+		ID:               102,
+		Enable:           true,
+		Type:             "mysql",
+		SourceConnection: mysqlDSN(t, harness.MySQLSource, sourceDB),
+		TargetConnection: mysqlDSN(t, harness.MySQLTarget, targetDB),
+		Mappings: []config.DatabaseMapping{{
+			Tables: []config.TableMapping{{
+				SourceTable: "table_that_does_not_exist",
+				TargetTable: "table_that_does_not_exist",
+			}},
+		}},
+	}
+
+	countAndLogTables(t.Context(), sc, quietLogger())
+
+	got := readMonitoringLog(t, conn)
+	if len(got) != 1 {
+		t.Fatalf("monitoring_log holds %d rows, want 1", len(got))
+	}
+	if got[0].SrcCount != -1 || got[0].TgtCount != -1 {
+		t.Fatalf("counts = %d -> %d, want -1 -> -1 — the sentinel appears to have been replaced; assert the new signal instead",
+			got[0].SrcCount, got[0].TgtCount)
+	}
+}
+
+// An unreachable source aborts the whole cycle before anything is written, so
+// a monitoring gap during an outage is indistinguishable from the monitor not
+// running at all: no row, no marker, only a log line.
+func TestAnUnreachableSourceWritesNothing(t *testing.T) {
+	conn := useMonitoringDB(t)
+
+	sc := config.SyncConfig{
+		ID:               103,
+		Enable:           true,
+		Type:             "mysql",
+		SourceConnection: "root:root@tcp(127.0.0.1:1)/source_db",
+		TargetConnection: mysqlDSN(t, harness.MySQLTarget, targetDB),
+		Mappings: []config.DatabaseMapping{{
+			Tables: []config.TableMapping{{SourceTable: "t", TargetTable: "t"}},
+		}},
+	}
+
+	countAndLogTables(t.Context(), sc, quietLogger())
+
+	if got := readMonitoringLog(t, conn); len(got) != 0 {
+		t.Fatalf("%d rows were written despite an unreachable source — an outage marker appears to have been added; assert it instead", len(got))
+	}
+}
+
+// ----------------------------------------------------------------- MongoDB
+
+func TestCountAndLogMongoDBRecordsBothSides(t *testing.T) {
+	conn := useMonitoringDB(t)
+
+	collection := harness.UniqueName("mon")
+	src := openMongo(t, harness.MongoSource)
+	tgt := openMongo(t, harness.MongoTarget)
+
+	srcColl := src.Database(sourceDB).Collection(collection)
+	tgtColl := tgt.Database(targetDB).Collection(collection)
+	t.Cleanup(func() {
+		_ = srcColl.Drop(context.Background())
+		_ = tgtColl.Drop(context.Background())
+	})
+
+	if _, err := srcColl.InsertMany(t.Context(), []interface{}{
+		bson.M{"n": 1}, bson.M{"n": 2}, bson.M{"n": 3}, bson.M{"n": 4},
+	}); err != nil {
+		t.Fatalf("seed source: %v", err)
+	}
+	if _, err := tgtColl.InsertMany(t.Context(), []interface{}{bson.M{"n": 1}}); err != nil {
+		t.Fatalf("seed target: %v", err)
+	}
+
+	sc := config.SyncConfig{
+		ID:               201,
+		Enable:           true,
+		Type:             "mongodb",
+		SourceConnection: "mongodb://" + harness.MongoSource + "/" + sourceDB + "?directConnection=true",
+		TargetConnection: "mongodb://" + harness.MongoTarget + "/" + targetDB + "?directConnection=true",
+		Mappings: []config.DatabaseMapping{{
+			SourceDatabase: sourceDB,
+			TargetDatabase: targetDB,
+			Tables:         []config.TableMapping{{SourceTable: collection, TargetTable: collection}},
+		}},
+	}
+
+	countAndLogTables(t.Context(), sc, quietLogger())
+
+	got := readMonitoringLog(t, conn)
+	if len(got) == 0 {
+		t.Fatal("monitoring_log is empty")
+	}
+	var found *monitoringRow
+	for i := range got {
+		if got[i].SrcTable == collection {
+			found = &got[i]
+		}
+	}
+	if found == nil {
+		t.Fatalf("no row for collection %q: %+v", collection, got)
+	}
+	if found.SrcCount != 4 || found.TgtCount != 1 {
+		t.Errorf("counts = %d -> %d, want 4 -> 1", found.SrcCount, found.TgtCount)
+	}
+	if found.DBType != "MONGODB" {
+		t.Errorf("db_type = %q, want MONGODB", found.DBType)
+	}
+}
+
+// ------------------------------------------------------------------- Redis
+
+func TestCountAndLogRedisRecordsDatabaseSizes(t *testing.T) {
+	conn := useMonitoringDB(t)
+
+	src := openRedis(t, harness.RedisSource, monitorRedisDB)
+	tgt := openRedis(t, harness.RedisTarget, monitorRedisDB)
+	if err := src.FlushDB(t.Context()).Err(); err != nil {
+		t.Fatalf("flush source: %v", err)
+	}
+	if err := tgt.FlushDB(t.Context()).Err(); err != nil {
+		t.Fatalf("flush target: %v", err)
+	}
+
+	for i := 0; i < 5; i++ {
+		if err := src.Set(t.Context(), fmt.Sprintf("k%d", i), i, 0).Err(); err != nil {
+			t.Fatalf("seed source: %v", err)
+		}
+	}
+	if err := tgt.Set(t.Context(), "k0", 0, 0).Err(); err != nil {
+		t.Fatalf("seed target: %v", err)
+	}
+
+	sc := config.SyncConfig{
+		ID:               301,
+		Enable:           true,
+		Type:             "redis",
+		SourceConnection: fmt.Sprintf("redis://%s/%d", harness.RedisSource, monitorRedisDB),
+		TargetConnection: fmt.Sprintf("redis://%s/%d", harness.RedisTarget, monitorRedisDB),
+		Mappings: []config.DatabaseMapping{{
+			Tables: []config.TableMapping{{SourceTable: "k*", TargetTable: "k*"}},
+		}},
+	}
+
+	countAndLogTables(t.Context(), sc, quietLogger())
+
+	got := readMonitoringLog(t, conn)
+	if len(got) != 1 {
+		t.Fatalf("monitoring_log holds %d rows, want 1: %+v", len(got), got)
+	}
+	if got[0].SrcCount != 5 || got[0].TgtCount != 1 {
+		t.Errorf("counts = %d -> %d, want 5 -> 1", got[0].SrcCount, got[0].TgtCount)
+	}
+	if got[0].DBType != "REDIS" {
+		t.Errorf("db_type = %q, want REDIS", got[0].DBType)
+	}
+}
+
+// The Redis monitor reports DBSize — the size of the whole database — and
+// writes one identical row per *mapping* rather than per table. src_table and
+// tgt_table are always empty, so the row cannot say which keys were compared,
+// and a task with two mappings produces two duplicate rows every cycle.
+func TestRedisMonitoringDuplicatesRowsPerMapping(t *testing.T) {
+	conn := useMonitoringDB(t)
+
+	src := openRedis(t, harness.RedisSource, monitorRedisDB)
+	tgt := openRedis(t, harness.RedisTarget, monitorRedisDB)
+	if err := src.FlushDB(t.Context()).Err(); err != nil {
+		t.Fatalf("flush source: %v", err)
+	}
+	if err := tgt.FlushDB(t.Context()).Err(); err != nil {
+		t.Fatalf("flush target: %v", err)
+	}
+	if err := src.Set(t.Context(), "only", 1, 0).Err(); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	sc := config.SyncConfig{
+		ID:               302,
+		Enable:           true,
+		Type:             "redis",
+		SourceConnection: fmt.Sprintf("redis://%s/%d", harness.RedisSource, monitorRedisDB),
+		TargetConnection: fmt.Sprintf("redis://%s/%d", harness.RedisTarget, monitorRedisDB),
+		Mappings: []config.DatabaseMapping{
+			{Tables: []config.TableMapping{{SourceTable: "a*", TargetTable: "a*"}}},
+			{Tables: []config.TableMapping{{SourceTable: "b*", TargetTable: "b*"}}},
+			{Tables: []config.TableMapping{{SourceTable: "c*", TargetTable: "c*"}}},
+		},
+	}
+
+	countAndLogTables(t.Context(), sc, quietLogger())
+
+	got := readMonitoringLog(t, conn)
+	if len(got) != 3 {
+		t.Fatalf("monitoring_log holds %d rows for 3 mappings — the loop appears to have changed; assert the new shape instead", len(got))
+	}
+	for i, r := range got {
+		if r.SrcTable != "" || r.TgtTable != "" {
+			t.Fatalf("row %d names tables (%q -> %q) — the monitor appears to record keys now", i, r.SrcTable, r.TgtTable)
+		}
+		if r.SrcCount != got[0].SrcCount || r.TgtCount != got[0].TgtCount {
+			t.Fatalf("row %d differs from row 0 — the rows appear to be per-mapping now", i)
+		}
+	}
+}
+
+// A Redis task with no mappings writes nothing at all: the DBSize calls run and
+// their results are discarded, because the only write sits inside the mapping
+// loop. Such a task is silently unmonitored.
+func TestARedisTaskWithoutMappingsIsUnmonitored(t *testing.T) {
+	conn := useMonitoringDB(t)
+
+	sc := config.SyncConfig{
+		ID:               303,
+		Enable:           true,
+		Type:             "redis",
+		SourceConnection: fmt.Sprintf("redis://%s/%d", harness.RedisSource, monitorRedisDB),
+		TargetConnection: fmt.Sprintf("redis://%s/%d", harness.RedisTarget, monitorRedisDB),
+	}
+
+	countAndLogTables(t.Context(), sc, quietLogger())
+
+	if got := readMonitoringLog(t, conn); len(got) != 0 {
+		t.Fatalf("%d rows were written for a task with no mappings — it appears to be handled now", len(got))
+	}
+}
+
+// ------------------------------------------------------------ dispatch
+
+func TestCountAndLogTablesIgnoresUnknownTypes(t *testing.T) {
+	conn := useMonitoringDB(t)
+
+	for _, typ := range []string{"cassandra", "", "sqlite"} {
+		sc := config.SyncConfig{ID: 401, Enable: true, Type: typ}
+		countAndLogTables(t.Context(), sc, quietLogger())
+	}
+
+	if got := readMonitoringLog(t, conn); len(got) != 0 {
+		t.Errorf("%d rows were written for unknown types", len(got))
+	}
+}
+
+// countAndLogTables lower-cases the type before dispatching, unlike
+// startSyncTasks in cmd/sync, which matches case-sensitively (T-094). The same
+// configuration value therefore reaches the monitor but not the syncer.
+func TestTheMonitorAcceptsCasingTheSyncerRejects(t *testing.T) {
+	conn := useMonitoringDB(t)
+
+	table := harness.UniqueName("case")
+	src := openMySQL(t, harness.MySQLSource, sourceDB)
+	tgt := openMySQL(t, harness.MySQLTarget, targetDB)
+	ddl := fmt.Sprintf("CREATE TABLE %s (id INT PRIMARY KEY)", table)
+	if _, err := src.Exec(ddl); err != nil {
+		t.Fatalf("create source table: %v", err)
+	}
+	if _, err := tgt.Exec(ddl); err != nil {
+		t.Fatalf("create target table: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = src.Exec("DROP TABLE " + table)
+		_, _ = tgt.Exec("DROP TABLE " + table)
+	})
+
+	sc := config.SyncConfig{
+		ID:               402,
+		Enable:           true,
+		Type:             "MySQL", // the spelling startSyncTasks drops
+		SourceConnection: mysqlDSN(t, harness.MySQLSource, sourceDB),
+		TargetConnection: mysqlDSN(t, harness.MySQLTarget, targetDB),
+		Mappings: []config.DatabaseMapping{{
+			Tables: []config.TableMapping{{SourceTable: table, TargetTable: table}},
+		}},
+	}
+
+	countAndLogTables(t.Context(), sc, quietLogger())
+
+	got := readMonitoringLog(t, conn)
+	if len(got) != 1 {
+		t.Fatalf("the monitor wrote %d rows for type %q — the two dispatchers appear to agree now", len(got), sc.Type)
+	}
+	if got[0].DBType != "MYSQL" {
+		t.Errorf("db_type = %q, want MYSQL", got[0].DBType)
+	}
+}
+
+// -------------------------------------------------------- monitoring loop
+
+func TestStartRowCountMonitoringWritesOnEachTick(t *testing.T) {
+	conn := useMonitoringDB(t)
+
+	table := harness.UniqueName("loop")
+	src := openMySQL(t, harness.MySQLSource, sourceDB)
+	tgt := openMySQL(t, harness.MySQLTarget, targetDB)
+	ddl := fmt.Sprintf("CREATE TABLE %s (id INT PRIMARY KEY)", table)
+	if _, err := src.Exec(ddl); err != nil {
+		t.Fatalf("create source table: %v", err)
+	}
+	if _, err := tgt.Exec(ddl); err != nil {
+		t.Fatalf("create target table: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = src.Exec("DROP TABLE " + table)
+		_, _ = tgt.Exec("DROP TABLE " + table)
+	})
+
+	enabled := config.SyncConfig{
+		ID:               501,
+		Enable:           true,
+		Type:             "mysql",
+		SourceConnection: mysqlDSN(t, harness.MySQLSource, sourceDB),
+		TargetConnection: mysqlDSN(t, harness.MySQLTarget, targetDB),
+		Mappings: []config.DatabaseMapping{{
+			Tables: []config.TableMapping{{SourceTable: table, TargetTable: table}},
+		}},
+	}
+	disabled := enabled
+	disabled.ID = 502
+	disabled.Enable = false
+
+	cfg := &config.Config{SyncConfigs: []config.SyncConfig{enabled, disabled}}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	StartRowCountMonitoring(ctx, cfg, quietLogger(), 300*time.Millisecond)
+
+	harness.Eventually(t, 5*time.Second, func() error {
+		if n := len(readMonitoringLog(t, conn)); n < 2 {
+			return fmt.Errorf("only %d rows so far", n)
+		}
+		return nil
+	})
+	cancel()
+
+	for _, r := range readMonitoringLog(t, conn) {
+		if r.TaskID != 501 {
+			t.Fatalf("a disabled task was monitored: %+v", r)
+		}
+	}
+}
+
+func TestStartRowCountMonitoringStopsOnCancel(t *testing.T) {
+	conn := useMonitoringDB(t)
+
+	sc := config.SyncConfig{
+		ID:               601,
+		Enable:           true,
+		Type:             "redis",
+		SourceConnection: fmt.Sprintf("redis://%s/%d", harness.RedisSource, monitorRedisDB),
+		TargetConnection: fmt.Sprintf("redis://%s/%d", harness.RedisTarget, monitorRedisDB),
+		Mappings: []config.DatabaseMapping{{
+			Tables: []config.TableMapping{{SourceTable: "*", TargetTable: "*"}},
+		}},
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	StartRowCountMonitoring(ctx, &config.Config{SyncConfigs: []config.SyncConfig{sc}},
+		quietLogger(), 200*time.Millisecond)
+
+	harness.Eventually(t, 5*time.Second, func() error {
+		if len(readMonitoringLog(t, conn)) == 0 {
+			return fmt.Errorf("nothing written yet")
+		}
+		return nil
+	})
+
+	cancel()
+	time.Sleep(600 * time.Millisecond) // two tick intervals
+	before := len(readMonitoringLog(t, conn))
+	time.Sleep(600 * time.Millisecond)
+
+	if after := len(readMonitoringLog(t, conn)); after != before {
+		t.Errorf("rows grew from %d to %d after cancellation", before, after)
+	}
+}
+
+// The ticker fires only after the first interval elapses, so a monitor
+// configured with the production interval writes nothing until then. Nothing is
+// recorded at startup, which means a process that restarts more often than its
+// monitor interval never produces a single measurement.
+func TestNoMeasurementIsTakenBeforeTheFirstTick(t *testing.T) {
+	conn := useMonitoringDB(t)
+
+	sc := config.SyncConfig{
+		ID:               701,
+		Enable:           true,
+		Type:             "redis",
+		SourceConnection: fmt.Sprintf("redis://%s/%d", harness.RedisSource, monitorRedisDB),
+		TargetConnection: fmt.Sprintf("redis://%s/%d", harness.RedisTarget, monitorRedisDB),
+		Mappings: []config.DatabaseMapping{{
+			Tables: []config.TableMapping{{SourceTable: "*", TargetTable: "*"}},
+		}},
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	StartRowCountMonitoring(ctx, &config.Config{SyncConfigs: []config.SyncConfig{sc}},
+		quietLogger(), time.Hour)
+
+	harness.Consistently(t, time.Second, func() error {
+		if n := len(readMonitoringLog(t, conn)); n != 0 {
+			return fmt.Errorf("%d rows were written before the first tick", n)
+		}
+		return nil
+	})
+}

--- a/pkg/utils/monitor_stats_test.go
+++ b/pkg/utils/monitor_stats_test.go
@@ -1,0 +1,587 @@
+package utils
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"testing"
+	"time"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+// useMonitoringDB points the package at a throwaway SQLite file carrying the
+// monitoring_log and changestream_statistics schemas, so the writers can be
+// exercised without touching the database tracked in this repository.
+func useMonitoringDB(t *testing.T) *sql.DB {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "sync.db")
+	t.Setenv("SYNC_DB_PATH", path)
+
+	conn, err := sql.Open("sqlite3", path)
+	if err != nil {
+		t.Fatalf("open temp sqlite: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+
+	const schema = `
+CREATE TABLE monitoring_log (
+    id             INTEGER PRIMARY KEY AUTOINCREMENT,
+    logged_at      DATETIME DEFAULT CURRENT_TIMESTAMP,
+    db_type        TEXT NOT NULL,
+    src_db         TEXT,
+    src_table      TEXT,
+    src_row_count  INTEGER,
+    tgt_db         TEXT,
+    tgt_table      TEXT,
+    tgt_row_count  INTEGER,
+    monitor_action TEXT,
+    sync_task_id   INTEGER
+);
+CREATE TABLE changestream_statistics (
+    id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    task_id         INTEGER NOT NULL,
+    collection_name VARCHAR(255) NOT NULL,
+    received        INTEGER DEFAULT 0,
+    executed        INTEGER DEFAULT 0,
+    pending         INTEGER DEFAULT 0,
+    errors          INTEGER DEFAULT 0,
+    inserted        INTEGER DEFAULT 0,
+    updated         INTEGER DEFAULT 0,
+    deleted         INTEGER DEFAULT 0,
+    last_updated    TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    created_at      TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(task_id, collection_name)
+);`
+	if _, err := conn.Exec(schema); err != nil {
+		t.Fatalf("create schema: %v", err)
+	}
+	return conn
+}
+
+// emptyDB points the package at a SQLite file with no tables, so the writers
+// hit a missing-table error.
+func emptyDB(t *testing.T) {
+	t.Helper()
+	t.Setenv("SYNC_DB_PATH", filepath.Join(t.TempDir(), "empty.db"))
+}
+
+type statsRow struct {
+	Received, Executed, Pending, Errors int
+	Inserted, Updated, Deleted          int
+	LastUpdated                         string
+}
+
+func readStats(t *testing.T, conn *sql.DB, taskID int, collection string) (statsRow, bool) {
+	t.Helper()
+
+	var r statsRow
+	err := conn.QueryRow(`
+		SELECT received, executed, pending, errors, inserted, updated, deleted, last_updated
+		FROM changestream_statistics WHERE task_id = ? AND collection_name = ?`,
+		taskID, collection).Scan(&r.Received, &r.Executed, &r.Pending, &r.Errors,
+		&r.Inserted, &r.Updated, &r.Deleted, &r.LastUpdated)
+	if err == sql.ErrNoRows {
+		return r, false
+	}
+	if err != nil {
+		t.Fatalf("read stats: %v", err)
+	}
+	return r, true
+}
+
+func countRows(t *testing.T, conn *sql.DB, table string) int {
+	t.Helper()
+
+	var n int
+	if err := conn.QueryRow("SELECT COUNT(*) FROM " + table).Scan(&n); err != nil {
+		t.Fatalf("count %s: %v", table, err)
+	}
+	return n
+}
+
+// ---------------------------------------------------------------- row counting
+
+func TestGetRowCountWithContext(t *testing.T) {
+	conn := useMonitoringDB(t)
+	if _, err := conn.Exec(`INSERT INTO monitoring_log (db_type) VALUES ('mysql'), ('mongodb')`); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	if got := getRowCountWithContext(t.Context(), conn, "monitoring_log"); got != 2 {
+		t.Errorf("getRowCountWithContext = %d, want 2", got)
+	}
+	if got := getRowCountWithContext(t.Context(), conn, "changestream_statistics"); got != 0 {
+		t.Errorf("getRowCountWithContext on an empty table = %d, want 0", got)
+	}
+}
+
+// Every failure is flattened into -1 and returned as if it were a count: a
+// missing table, a permission error, a dropped connection and a cancelled
+// context are indistinguishable from one another and, once stored, from real
+// data. storeMonitoringLog then writes -1 into src_row_count / tgt_row_count,
+// so monitoring_log accumulates rows that look like measurements but are not.
+func TestARowCountFailureIsIndistinguishableFromData(t *testing.T) {
+	conn := useMonitoringDB(t)
+
+	if got := getRowCountWithContext(t.Context(), conn, "no_such_table"); got != -1 {
+		t.Fatalf("getRowCountWithContext on a missing table = %d, want -1 — errors appear to be reported now; assert the new signal instead", got)
+	}
+
+	cancelled, cancelNow := context.WithCancel(t.Context())
+	cancelNow()
+	if got := getRowCountWithContext(cancelled, conn, "monitoring_log"); got != -1 {
+		t.Errorf("getRowCountWithContext with a cancelled context = %d, want -1", got)
+	}
+
+	// And -1 is persisted as though it were a row count.
+	storeMonitoringLog(7, "mysql", "src", "orders", -1, "tgt", "orders", -1, "row_count_minutely")
+
+	var srcCount, tgtCount int64
+	if err := conn.QueryRow(
+		`SELECT src_row_count, tgt_row_count FROM monitoring_log WHERE sync_task_id = 7`,
+	).Scan(&srcCount, &tgtCount); err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if srcCount != -1 || tgtCount != -1 {
+		t.Fatalf("stored counts = %d/%d — the sentinel appears to be filtered now", srcCount, tgtCount)
+	}
+}
+
+// The table name is interpolated straight into the SQL text. Table names come
+// from the sync task configuration, so anyone who can create or edit a task
+// through the API controls a fragment of a query that runs against the source
+// and target databases.
+func TestTheTableNameIsInterpolatedIntoTheQuery(t *testing.T) {
+	conn := useMonitoringDB(t)
+	if _, err := conn.Exec(`INSERT INTO monitoring_log (db_type) VALUES ('a'), ('b'), ('c')`); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	// A "table name" that is really a query fragment is accepted and changes
+	// what the count means.
+	if got := getRowCountWithContext(t.Context(), conn, "monitoring_log WHERE db_type = 'a'"); got != 1 {
+		t.Fatalf("a WHERE clause smuggled through the table name returned %d — the name appears to be validated or quoted now; assert the rejection instead", got)
+	}
+}
+
+// ------------------------------------------------------------ monitoring_log
+
+func TestStoreMonitoringLogWritesEveryColumn(t *testing.T) {
+	conn := useMonitoringDB(t)
+
+	storeMonitoringLog(42, "mysql", "source_db", "orders", 1200, "target_db", "orders", 1199, "row_count_minutely")
+
+	var (
+		taskID                int
+		dbType, srcDB, srcTbl string
+		srcCount              int64
+		tgtDB, tgtTbl, action string
+		tgtCount              int64
+		loggedAt              time.Time
+	)
+	err := conn.QueryRow(`
+		SELECT sync_task_id, db_type, src_db, src_table, src_row_count,
+		       tgt_db, tgt_table, tgt_row_count, monitor_action, logged_at
+		FROM monitoring_log`).Scan(&taskID, &dbType, &srcDB, &srcTbl, &srcCount,
+		&tgtDB, &tgtTbl, &tgtCount, &action, &loggedAt)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+
+	if taskID != 42 || dbType != "mysql" || srcDB != "source_db" || srcTbl != "orders" ||
+		srcCount != 1200 || tgtDB != "target_db" || tgtTbl != "orders" || tgtCount != 1199 ||
+		action != "row_count_minutely" {
+		t.Errorf("row = %d %q %q.%q(%d) -> %q.%q(%d) %q",
+			taskID, dbType, srcDB, srcTbl, srcCount, tgtDB, tgtTbl, tgtCount, action)
+	}
+	// The driver converts DATETIME columns to time.Time, so this is what a
+	// reader actually gets back.
+	if d := time.Since(loggedAt); d < -2*time.Second || d > 2*time.Second {
+		t.Errorf("logged_at = %v, %v away from now", loggedAt, d)
+	}
+}
+
+func TestStoreMonitoringLogAppends(t *testing.T) {
+	conn := useMonitoringDB(t)
+
+	for i := 0; i < 3; i++ {
+		storeMonitoringLog(1, "mongodb", "s", "c", int64(i), "t", "c", int64(i), "row_count_minutely")
+	}
+
+	if got := countRows(t, conn, "monitoring_log"); got != 3 {
+		t.Errorf("monitoring_log holds %d rows, want 3", got)
+	}
+}
+
+// storeMonitoringLog returns nothing and swallows every failure into a log
+// line. If monitoring_log is missing — a fresh database, a failed migration —
+// every monitoring cycle silently records nothing while the caller carries on
+// as if the measurement had been persisted.
+func TestStoreMonitoringLogSwallowsAMissingTable(t *testing.T) {
+	emptyDB(t)
+
+	// No panic, no error, no way for the caller to notice.
+	storeMonitoringLog(1, "mysql", "s", "orders", 10, "t", "orders", 10, "row_count_minutely")
+}
+
+// --------------------------------------------------- changestream_statistics
+
+func TestStoreChangeStreamStatisticsUpserts(t *testing.T) {
+	conn := useMonitoringDB(t)
+
+	streams := map[string]*ChangeStreamInfo{
+		"source_db.orders": {
+			SyncTaskID: 1, Active: true,
+			ReceivedEvents: 100, ExecutedEvents: 90, ErrorCount: 2,
+			InsertedCount: 50, UpdatedCount: 30, DeletedCount: 10,
+		},
+	}
+
+	if err := StoreChangeStreamStatistics(1, streams); err != nil {
+		t.Fatalf("StoreChangeStreamStatistics: %v", err)
+	}
+
+	got, ok := readStats(t, conn, 1, "source_db.orders")
+	if !ok {
+		t.Fatal("no row was written")
+	}
+	want := statsRow{Received: 100, Executed: 90, Pending: 10, Errors: 2, Inserted: 50, Updated: 30, Deleted: 10}
+	if got.Received != want.Received || got.Executed != want.Executed || got.Pending != want.Pending ||
+		got.Errors != want.Errors || got.Inserted != want.Inserted || got.Updated != want.Updated ||
+		got.Deleted != want.Deleted {
+		t.Errorf("row = %+v, want %+v", got, want)
+	}
+
+	// A second call for the same collection updates in place.
+	streams["source_db.orders"].ReceivedEvents = 200
+	streams["source_db.orders"].ExecutedEvents = 200
+	if err := StoreChangeStreamStatistics(1, streams); err != nil {
+		t.Fatalf("second store: %v", err)
+	}
+
+	if n := countRows(t, conn, "changestream_statistics"); n != 1 {
+		t.Errorf("changestream_statistics holds %d rows, want 1 after an upsert", n)
+	}
+	got, _ = readStats(t, conn, 1, "source_db.orders")
+	if got.Received != 200 || got.Executed != 200 || got.Pending != 0 {
+		t.Errorf("after the upsert row = %+v, want received/executed 200 and pending 0", got)
+	}
+}
+
+func TestStoreChangeStreamStatisticsClampsPendingAtZero(t *testing.T) {
+	conn := useMonitoringDB(t)
+
+	// More executed than received: the syncer counts these independently, so
+	// the difference can go negative.
+	streams := map[string]*ChangeStreamInfo{
+		"db.coll": {SyncTaskID: 1, Active: true, ReceivedEvents: 5, ExecutedEvents: 9},
+	}
+	if err := StoreChangeStreamStatistics(1, streams); err != nil {
+		t.Fatalf("StoreChangeStreamStatistics: %v", err)
+	}
+
+	got, _ := readStats(t, conn, 1, "db.coll")
+	if got.Pending != 0 {
+		t.Errorf("pending = %d, want 0", got.Pending)
+	}
+}
+
+// Inactive streams are skipped rather than marked, so a collection whose change
+// stream has died keeps its last row forever. The table cannot distinguish "no
+// events since the last cycle" from "this stream stopped and nobody noticed".
+func TestAnInactiveStreamKeepsItsLastRow(t *testing.T) {
+	conn := useMonitoringDB(t)
+
+	stream := &ChangeStreamInfo{SyncTaskID: 1, Active: true, ReceivedEvents: 100, ExecutedEvents: 100}
+	streams := map[string]*ChangeStreamInfo{"db.coll": stream}
+
+	if err := StoreChangeStreamStatistics(1, streams); err != nil {
+		t.Fatalf("first store: %v", err)
+	}
+
+	stream.Active = false
+	stream.ReceivedEvents = 500 // would be written if inactive streams were stored
+	if err := StoreChangeStreamStatistics(1, streams); err != nil {
+		t.Fatalf("second store: %v", err)
+	}
+
+	got, ok := readStats(t, conn, 1, "db.coll")
+	if !ok {
+		t.Fatal("the row was removed")
+	}
+	if got.Received != 100 {
+		t.Fatalf("received = %d — inactive streams appear to be recorded now; assert the new signal instead", got.Received)
+	}
+}
+
+// The whole registry that feeds this table is disconnected: RegisterChangeStream,
+// UpdateChangeStreamActivity, UpdateChangeStreamDetailedActivity,
+// AccumulateChangeStreamActivity, RecordChangeStreamError and
+// DeactivateChangeStream have no callers anywhere outside their own
+// definitions, so changeStreamTracker is permanently empty. The monitoring loop
+// calls GetActiveChangeStreamsByTaskID, gets an empty map, and hands it here —
+// where the upsert loop has nothing to iterate. StoreChangeStreamStatistics
+// returns nil, the caller logs a success, and not one row is ever written or
+// updated. This is why the production table holds 33 rows created in 2025 whose
+// counters are all still zero (T-052).
+func TestAnEmptyRegistryWritesNothingAndReportsSuccess(t *testing.T) {
+	conn := useMonitoringDB(t)
+
+	// What GetActiveChangeStreamsByTaskID returns in production.
+	resetTracker(t)
+	empty := GetActiveChangeStreamsByTaskID(1)
+	if len(empty) != 0 {
+		t.Fatalf("the tracker is not empty: %d entries", len(empty))
+	}
+
+	if err := StoreChangeStreamStatistics(1, empty); err != nil {
+		t.Fatalf("StoreChangeStreamStatistics(empty) = %v — an empty registry appears to be reported now; assert the error instead", err)
+	}
+	if n := countRows(t, conn, "changestream_statistics"); n != 0 {
+		t.Fatalf("%d rows were written from an empty registry", n)
+	}
+}
+
+func TestStoreChangeStreamStatisticsReportsAMissingTable(t *testing.T) {
+	emptyDB(t)
+
+	streams := map[string]*ChangeStreamInfo{
+		"db.coll": {SyncTaskID: 1, Active: true, ReceivedEvents: 1, ExecutedEvents: 1},
+	}
+	err := StoreChangeStreamStatistics(1, streams)
+
+	if err == nil {
+		t.Fatal("StoreChangeStreamStatistics() = nil with no changestream_statistics table")
+	}
+}
+
+func TestStoreChangeStreamStatisticsSeparatesTasks(t *testing.T) {
+	conn := useMonitoringDB(t)
+
+	for _, taskID := range []int{1, 2} {
+		streams := map[string]*ChangeStreamInfo{
+			"db.coll": {SyncTaskID: taskID, Active: true, ReceivedEvents: taskID * 10, ExecutedEvents: taskID * 10},
+		}
+		if err := StoreChangeStreamStatistics(taskID, streams); err != nil {
+			t.Fatalf("store for task %d: %v", taskID, err)
+		}
+	}
+
+	if n := countRows(t, conn, "changestream_statistics"); n != 2 {
+		t.Errorf("changestream_statistics holds %d rows, want one per task", n)
+	}
+	for _, taskID := range []int{1, 2} {
+		got, ok := readStats(t, conn, taskID, "db.coll")
+		if !ok {
+			t.Fatalf("no row for task %d", taskID)
+		}
+		if got.Received != taskID*10 {
+			t.Errorf("task %d received = %d, want %d", taskID, got.Received, taskID*10)
+		}
+	}
+}
+
+// ------------------------------------------------------------- daily reset
+
+func TestResetDailyStatisticsIsANoOpWithNoRecords(t *testing.T) {
+	conn := useMonitoringDB(t)
+
+	tx, err := conn.Begin()
+	if err != nil {
+		t.Fatalf("begin: %v", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	if err := resetDailyStatisticsIfNeeded(tx, 1); err != nil {
+		t.Errorf("resetDailyStatisticsIfNeeded on an empty table = %v", err)
+	}
+}
+
+func TestResetDailyStatisticsClearsYesterdaysCounters(t *testing.T) {
+	conn := useMonitoringDB(t)
+
+	// A row last updated two days ago, in the CURRENT_TIMESTAMP (UTC) format
+	// the writer uses.
+	twoDaysAgo := time.Now().UTC().AddDate(0, 0, -2).Format("2006-01-02 15:04:05")
+	if _, err := conn.Exec(`
+		INSERT INTO changestream_statistics
+			(task_id, collection_name, received, executed, pending, errors, inserted, updated, deleted, last_updated)
+		VALUES (1, 'db.coll', 500, 480, 20, 3, 200, 200, 80, ?)`, twoDaysAgo); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	tx, err := conn.Begin()
+	if err != nil {
+		t.Fatalf("begin: %v", err)
+	}
+	if err := resetDailyStatisticsIfNeeded(tx, 1); err != nil {
+		t.Fatalf("resetDailyStatisticsIfNeeded: %v", err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+
+	got, ok := readStats(t, conn, 1, "db.coll")
+	if !ok {
+		t.Fatal("the row was deleted rather than reset")
+	}
+	if got.Received != 0 || got.Executed != 0 || got.Pending != 0 || got.Errors != 0 ||
+		got.Inserted != 0 || got.Updated != 0 || got.Deleted != 0 {
+		t.Errorf("row = %+v, want every counter zeroed", got)
+	}
+}
+
+func TestResetDailyStatisticsLeavesTodaysCountersAlone(t *testing.T) {
+	conn := useMonitoringDB(t)
+
+	now := time.Now().UTC().Format("2006-01-02 15:04:05")
+	if _, err := conn.Exec(`
+		INSERT INTO changestream_statistics
+			(task_id, collection_name, received, executed, last_updated)
+		VALUES (1, 'db.coll', 77, 70, ?)`, now); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	tx, err := conn.Begin()
+	if err != nil {
+		t.Fatalf("begin: %v", err)
+	}
+	if err := resetDailyStatisticsIfNeeded(tx, 1); err != nil {
+		t.Fatalf("resetDailyStatisticsIfNeeded: %v", err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+
+	got, _ := readStats(t, conn, 1, "db.coll")
+	if got.Received != 77 || got.Executed != 70 {
+		t.Errorf("row = %+v, want the counters untouched", got)
+	}
+}
+
+func TestResetDailyStatisticsOnlyTouchesItsOwnTask(t *testing.T) {
+	conn := useMonitoringDB(t)
+
+	twoDaysAgo := time.Now().UTC().AddDate(0, 0, -2).Format("2006-01-02 15:04:05")
+	for _, taskID := range []int{1, 2} {
+		if _, err := conn.Exec(`
+			INSERT INTO changestream_statistics
+				(task_id, collection_name, received, executed, last_updated)
+			VALUES (?, 'db.coll', 100, 100, ?)`, taskID, twoDaysAgo); err != nil {
+			t.Fatalf("seed task %d: %v", taskID, err)
+		}
+	}
+
+	tx, err := conn.Begin()
+	if err != nil {
+		t.Fatalf("begin: %v", err)
+	}
+	if err := resetDailyStatisticsIfNeeded(tx, 1); err != nil {
+		t.Fatalf("resetDailyStatisticsIfNeeded: %v", err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+
+	if got, _ := readStats(t, conn, 1, "db.coll"); got.Received != 0 {
+		t.Errorf("task 1 received = %d, want 0", got.Received)
+	}
+	if got, _ := readStats(t, conn, 2, "db.coll"); got.Received != 100 {
+		t.Errorf("task 2 received = %d, want it left alone", got.Received)
+	}
+}
+
+// A last_updated value the writer never produces aborts the whole cycle:
+// resetDailyStatisticsIfNeeded parses it with a single fixed layout and returns
+// an error, which StoreChangeStreamStatistics propagates before writing
+// anything. One malformed timestamp — from a manual edit or an older schema —
+// stops statistics for that task permanently.
+func TestAnUnparseableTimestampStopsStatisticsForTheTask(t *testing.T) {
+	conn := useMonitoringDB(t)
+
+	if _, err := conn.Exec(`
+		INSERT INTO changestream_statistics
+			(task_id, collection_name, received, last_updated)
+		VALUES (1, 'db.coll', 5, '2026-08-19T00:00:00Z')`); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	streams := map[string]*ChangeStreamInfo{
+		"db.coll": {SyncTaskID: 1, Active: true, ReceivedEvents: 999, ExecutedEvents: 999},
+	}
+	err := StoreChangeStreamStatistics(1, streams)
+
+	if err == nil {
+		t.Fatalf("StoreChangeStreamStatistics() = nil — the timestamp appears to be tolerated now; assert the write instead")
+	}
+
+	got, _ := readStats(t, conn, 1, "db.coll")
+	if got.Received != 5 {
+		t.Errorf("received = %d, want the pre-existing 5 (nothing should have been written)", got.Received)
+	}
+}
+
+// ------------------------------------------------------ in-memory reset
+
+func TestResetInMemoryStatistics(t *testing.T) {
+	resetTracker(t)
+
+	RegisterChangeStream(1, "db", "a")
+	RegisterChangeStream(1, "db", "b")
+	RegisterChangeStream(2, "db", "c")
+	AccumulateChangeStreamActivity("db", "a", 10, 10, 8, 5, 3, 2)
+	AccumulateChangeStreamActivity("db", "c", 20, 20, 20, 10, 5, 5)
+	RecordChangeStreamError("db", "a", "boom")
+
+	before := GetActiveChangeStreamsByTaskID(1)["db.a"]
+	created, lastActivity, active := before.Created, before.LastActivity, before.Active
+
+	resetInMemoryStatistics(1)
+
+	a := GetActiveChangeStreamsByTaskID(1)["db.a"]
+	if a.ReceivedEvents != 0 || a.ExecutedEvents != 0 || a.EventCount != 0 ||
+		a.InsertedCount != 0 || a.UpdatedCount != 0 || a.DeletedCount != 0 || a.ErrorCount != 0 {
+		t.Errorf("task 1 counters were not cleared: %+v", a)
+	}
+	if !a.Created.Equal(created) || !a.LastActivity.Equal(lastActivity) || a.Active != active {
+		t.Error("resetInMemoryStatistics changed a field other than the counters")
+	}
+
+	c := GetActiveChangeStreamsByTaskID(2)["db.c"]
+	if c.ReceivedEvents != 20 {
+		t.Errorf("task 2 received = %d, want it left alone", c.ReceivedEvents)
+	}
+}
+
+// The error message is kept while the count that justified it is cleared, so
+// after a daily reset a stream reports zero errors alongside a stale
+// LastErrorMsg from a previous day.
+func TestResetInMemoryStatisticsKeepsTheStaleErrorMessage(t *testing.T) {
+	resetTracker(t)
+
+	RegisterChangeStream(1, "db", "a")
+	RecordChangeStreamError("db", "a", "yesterday's failure")
+
+	resetInMemoryStatistics(1)
+
+	a := GetActiveChangeStreamsByTaskID(1)["db.a"]
+	if a.ErrorCount != 0 {
+		t.Fatalf("ErrorCount = %d, want 0", a.ErrorCount)
+	}
+	if a.LastErrorMsg != "yesterday's failure" {
+		t.Fatalf("LastErrorMsg = %q — it appears to be cleared now; assert the empty value instead", a.LastErrorMsg)
+	}
+}
+
+func TestResetInMemoryStatisticsOnAnUnknownTask(t *testing.T) {
+	resetTracker(t)
+	RegisterChangeStream(1, "db", "a")
+
+	resetInMemoryStatistics(99) // must not panic or touch task 1
+
+	if n := len(GetActiveChangeStreamsByTaskID(1)); n != 1 {
+		t.Errorf("task 1 has %d streams, want 1", n)
+	}
+}

--- a/pkg/utils/monitor_test.go
+++ b/pkg/utils/monitor_test.go
@@ -1,0 +1,262 @@
+package utils
+
+import (
+	"testing"
+	"time"
+)
+
+// resetTracker clears the package-level registry so each test starts clean.
+// The registry is global state, so these tests must not run in parallel.
+func resetTracker(t *testing.T) {
+	t.Helper()
+
+	csTrackerMutex.Lock()
+	changeStreamTracker = make(map[string]*ChangeStreamInfo)
+	csTrackerMutex.Unlock()
+
+	t.Cleanup(func() {
+		csTrackerMutex.Lock()
+		changeStreamTracker = make(map[string]*ChangeStreamInfo)
+		csTrackerMutex.Unlock()
+	})
+}
+
+func TestRegisterChangeStream(t *testing.T) {
+	resetTracker(t)
+
+	RegisterChangeStream(7, "source_db", "users")
+
+	streams := GetActiveChangeStreams()
+	if len(streams) != 1 {
+		t.Fatalf("registry holds %d streams, want 1", len(streams))
+	}
+	cs, ok := streams["source_db.users"]
+	if !ok {
+		t.Fatalf("registry keys are %v, want source_db.users", streams)
+	}
+	if cs.SyncTaskID != 7 || cs.Database != "source_db" || cs.Collection != "users" {
+		t.Errorf("entry = %+v", cs)
+	}
+	if !cs.Active {
+		t.Error("a freshly registered stream is not active")
+	}
+	if cs.EventCount != 0 || cs.ErrorCount != 0 {
+		t.Errorf("counters start at %d/%d, want zero", cs.EventCount, cs.ErrorCount)
+	}
+	if cs.Created.IsZero() || cs.LastActivity.IsZero() {
+		t.Error("timestamps were not set")
+	}
+}
+
+// TestRegisterChangeStreamResetsCounters records that re-registering a stream
+// discards its statistics. The guardian loop reopens a change stream on every
+// recoverable error, so any reconnect would zero the counters that the
+// monitoring UI reports — cumulative totals cannot survive a network blip.
+func TestRegisterChangeStreamResetsCounters(t *testing.T) {
+	resetTracker(t)
+
+	RegisterChangeStream(1, "db", "coll")
+	AccumulateChangeStreamActivity("db", "coll", 10, 10, 10, 5, 3, 2)
+
+	before := GetActiveChangeStreams()["db.coll"]
+	if before.EventCount != 10 {
+		t.Fatalf("setup failed: EventCount = %d", before.EventCount)
+	}
+
+	RegisterChangeStream(1, "db", "coll")
+
+	after := GetActiveChangeStreams()["db.coll"]
+	if after.EventCount != 0 || after.ReceivedEvents != 0 || after.InsertedCount != 0 {
+		t.Errorf("counters survived re-registration (%d/%d/%d); if that is now "+
+			"intended, assert the preserved values instead",
+			after.EventCount, after.ReceivedEvents, after.InsertedCount)
+	}
+}
+
+// TestChangeStreamKeyIgnoresTaskID records that entries are keyed on
+// database.collection with no task identifier, so two tasks replicating the
+// same source collection to different targets overwrite one another. The second
+// registration wins, and GetActiveChangeStreamsByTaskID then reports nothing for
+// the first task.
+func TestChangeStreamKeyIgnoresTaskID(t *testing.T) {
+	resetTracker(t)
+
+	RegisterChangeStream(1, "db", "coll")
+	RegisterChangeStream(2, "db", "coll")
+
+	if n := len(GetActiveChangeStreams()); n != 1 {
+		t.Fatalf("registry holds %d entries; the key may now include the task id, "+
+			"so assert the separate entries instead", n)
+	}
+	if got := GetActiveChangeStreams()["db.coll"].SyncTaskID; got != 2 {
+		t.Errorf("the surviving entry belongs to task %d, want 2", got)
+	}
+	if n := len(GetActiveChangeStreamsByTaskID(1)); n != 0 {
+		t.Errorf("task 1 still reports %d streams after task 2 overwrote the entry", n)
+	}
+}
+
+// TestUpdateVersusAccumulateSemantics pins a trap in the API: the two updater
+// functions treat the same fields differently. UpdateChangeStreamActivity
+// *replaces* ReceivedEvents and ExecutedEvents while *adding* to EventCount,
+// whereas AccumulateChangeStreamActivity adds to all of them. Mixing the two
+// against one stream produces totals that mean neither thing.
+func TestUpdateVersusAccumulateSemantics(t *testing.T) {
+	t.Run("update replaces received and executed", func(t *testing.T) {
+		resetTracker(t)
+		RegisterChangeStream(1, "db", "coll")
+
+		UpdateChangeStreamActivity("db", "coll", 5, 100, 90)
+		UpdateChangeStreamActivity("db", "coll", 5, 200, 180)
+
+		cs := GetActiveChangeStreams()["db.coll"]
+		if cs.ReceivedEvents != 200 || cs.ExecutedEvents != 180 {
+			t.Errorf("received/executed = %d/%d, want 200/180 (replaced)",
+				cs.ReceivedEvents, cs.ExecutedEvents)
+		}
+		// EventCount is the exception: it accumulates.
+		if cs.EventCount != 10 {
+			t.Errorf("EventCount = %d, want 10 (accumulated)", cs.EventCount)
+		}
+	})
+
+	t.Run("accumulate adds to everything", func(t *testing.T) {
+		resetTracker(t)
+		RegisterChangeStream(1, "db", "coll")
+
+		AccumulateChangeStreamActivity("db", "coll", 5, 100, 90, 60, 20, 10)
+		AccumulateChangeStreamActivity("db", "coll", 5, 100, 90, 60, 20, 10)
+
+		cs := GetActiveChangeStreams()["db.coll"]
+		if cs.ReceivedEvents != 200 || cs.ExecutedEvents != 180 {
+			t.Errorf("received/executed = %d/%d, want 200/180 (accumulated)",
+				cs.ReceivedEvents, cs.ExecutedEvents)
+		}
+		if cs.InsertedCount != 120 || cs.UpdatedCount != 40 || cs.DeletedCount != 20 {
+			t.Errorf("operation counts = %d/%d/%d, want 120/40/20",
+				cs.InsertedCount, cs.UpdatedCount, cs.DeletedCount)
+		}
+	})
+}
+
+func TestUpdateChangeStreamDetailedActivityReplaces(t *testing.T) {
+	resetTracker(t)
+	RegisterChangeStream(1, "db", "coll")
+
+	UpdateChangeStreamDetailedActivity("db", "coll", 1, 10, 9, 5, 3, 1)
+	UpdateChangeStreamDetailedActivity("db", "coll", 1, 20, 18, 10, 6, 2)
+
+	cs := GetActiveChangeStreams()["db.coll"]
+	if cs.InsertedCount != 10 || cs.UpdatedCount != 6 || cs.DeletedCount != 2 {
+		t.Errorf("operation counts = %d/%d/%d, want 10/6/2 (replaced)",
+			cs.InsertedCount, cs.UpdatedCount, cs.DeletedCount)
+	}
+}
+
+func TestUpdatesToUnknownStreamAreDropped(t *testing.T) {
+	resetTracker(t)
+
+	// Every updater silently returns when the key is absent, so activity for a
+	// stream that was never registered is lost without a trace.
+	UpdateChangeStreamActivity("db", "coll", 5, 10, 10)
+	AccumulateChangeStreamActivity("db", "coll", 5, 10, 10, 1, 1, 1)
+	RecordChangeStreamError("db", "coll", "boom")
+	DeactivateChangeStream("db", "coll")
+
+	if n := len(GetActiveChangeStreams()); n != 0 {
+		t.Errorf("registry gained %d entries from updates alone", n)
+	}
+}
+
+func TestRecordChangeStreamError(t *testing.T) {
+	resetTracker(t)
+	RegisterChangeStream(1, "db", "coll")
+
+	RecordChangeStreamError("db", "coll", "connection refused")
+	RecordChangeStreamError("db", "coll", "cursor not found")
+
+	cs := GetActiveChangeStreams()["db.coll"]
+	if cs.ErrorCount != 2 {
+		t.Errorf("ErrorCount = %d, want 2", cs.ErrorCount)
+	}
+	// Only the most recent message is kept.
+	if cs.LastErrorMsg != "cursor not found" {
+		t.Errorf("LastErrorMsg = %q, want the most recent", cs.LastErrorMsg)
+	}
+	if cs.LastErrorTime.IsZero() {
+		t.Error("LastErrorTime was not set")
+	}
+	// An error does not deactivate the stream.
+	if !cs.Active {
+		t.Error("recording an error deactivated the stream")
+	}
+}
+
+func TestDeactivateChangeStream(t *testing.T) {
+	resetTracker(t)
+	RegisterChangeStream(1, "db", "coll")
+
+	DeactivateChangeStream("db", "coll")
+
+	// The entry stays in the registry; only the flag changes.
+	if n := len(GetActiveChangeStreams()); n != 1 {
+		t.Errorf("GetActiveChangeStreams returns %d entries; despite the name it "+
+			"returns every entry, active or not", n)
+	}
+	if GetActiveChangeStreams()["db.coll"].Active {
+		t.Error("the stream is still marked active")
+	}
+	// The by-task view does filter on the flag.
+	if n := len(GetActiveChangeStreamsByTaskID(1)); n != 0 {
+		t.Errorf("GetActiveChangeStreamsByTaskID returns %d entries, want 0", n)
+	}
+}
+
+func TestGetActiveChangeStreamsByTaskID(t *testing.T) {
+	resetTracker(t)
+	RegisterChangeStream(1, "db", "a")
+	RegisterChangeStream(1, "db", "b")
+	RegisterChangeStream(2, "db", "c")
+
+	if n := len(GetActiveChangeStreamsByTaskID(1)); n != 2 {
+		t.Errorf("task 1 has %d streams, want 2", n)
+	}
+	if n := len(GetActiveChangeStreamsByTaskID(2)); n != 1 {
+		t.Errorf("task 2 has %d streams, want 1", n)
+	}
+	if n := len(GetActiveChangeStreamsByTaskID(99)); n != 0 {
+		t.Errorf("an unknown task has %d streams, want 0", n)
+	}
+}
+
+// TestGetActiveChangeStreamsSharesPointers records that the defensive copy is
+// shallow. The comment in the implementation says the copy avoids concurrency
+// issues, but only the map is copied — the values are the same pointers, so a
+// caller reading a returned entry races with the writers that hold the mutex.
+func TestGetActiveChangeStreamsSharesPointers(t *testing.T) {
+	resetTracker(t)
+	RegisterChangeStream(1, "db", "coll")
+
+	snapshot := GetActiveChangeStreams()["db.coll"]
+	AccumulateChangeStreamActivity("db", "coll", 1, 1, 1, 1, 0, 0)
+
+	if snapshot.EventCount == 0 {
+		t.Skip("the snapshot is now a deep copy, which removes the race")
+	}
+	t.Logf("the returned entry changed under the caller (EventCount=%d): the copy "+
+		"is shallow and the values are shared", snapshot.EventCount)
+}
+
+func TestChangeStreamActivityUpdatesTimestamp(t *testing.T) {
+	resetTracker(t)
+	RegisterChangeStream(1, "db", "coll")
+
+	before := GetActiveChangeStreams()["db.coll"].LastActivity
+	time.Sleep(2 * time.Millisecond)
+	AccumulateChangeStreamActivity("db", "coll", 1, 1, 1, 1, 0, 0)
+	after := GetActiveChangeStreams()["db.coll"].LastActivity
+
+	if !after.After(before) {
+		t.Errorf("LastActivity did not advance: %v -> %v", before, after)
+	}
+}

--- a/pkg/utils/query_counter_test.go
+++ b/pkg/utils/query_counter_test.go
@@ -1,0 +1,169 @@
+package utils
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"go.mongodb.org/mongo-driver/bson"
+)
+
+func newCounter(t *testing.T) *QueryCounter {
+	t.Helper()
+
+	logger := logrus.New()
+	logger.SetLevel(logrus.PanicLevel)
+	return NewQueryCounter(logger)
+}
+
+func TestFormatValue(t *testing.T) {
+	qc := newCounter(t)
+	ts := time.Date(2026, 8, 21, 13, 45, 30, 0, time.UTC)
+
+	tests := []struct {
+		name  string
+		value interface{}
+		want  string
+	}{
+		{"time becomes ISODate", ts, `ISODate("2026-08-21T13:45:30.000Z")`},
+		{"string is quoted", "active", `"active"`},
+		{"int", 42, "42"},
+		{"int64", int64(42), "42"},
+		{"float", 1.5, "1.5"},
+		{"bool falls through to %v", true, "true"},
+		{"nil falls through to %v", nil, "<nil>"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := qc.formatValue(tt.value); got != tt.want {
+				t.Errorf("formatValue(%#v) = %q, want %q", tt.value, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFormatFilterCondition(t *testing.T) {
+	qc := newCounter(t)
+	ts := time.Date(2026, 8, 21, 0, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name  string
+		field string
+		value interface{}
+		want  string
+	}{
+		{"scalar equality", "status", "active", `status: "active"`},
+		{"numeric equality", "count", 3, "count: 3"},
+		{
+			"gte with a time renders as ISODate",
+			"created_at", bson.M{"$gte": ts},
+			`created_at: {$gte: ISODate("2026-08-21T00:00:00.000Z")}`,
+		},
+		{
+			"lt with a time renders as a plain value",
+			// Only $gte and $lte have the ISODate special case; $lt and $gt fall
+			// through to formatValue, which also renders times as ISODate.
+			"created_at", bson.M{"$lt": ts},
+			`created_at: {$lt: ISODate("2026-08-21T00:00:00.000Z")}`,
+		},
+		{"ne", "status", bson.M{"$ne": "deleted"}, `status: {$ne: "deleted"}`},
+		{"unknown operator passes through", "n", bson.M{"$in": 1}, "n: {$in: 1}"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := qc.formatFilterCondition(tt.field, tt.value); got != tt.want {
+				t.Errorf("formatFilterCondition(%q, %#v) = %q, want %q",
+					tt.field, tt.value, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestFormatFilterConditionDropsEmptyOperatorMaps records that an empty bson.M
+// yields an empty string, which buildReadableQueryString then skips. The
+// rendered query therefore claims a filter that the real count did not use.
+func TestFormatFilterConditionDropsEmptyOperatorMaps(t *testing.T) {
+	qc := newCounter(t)
+
+	if got := qc.formatFilterCondition("created_at", bson.M{}); got != "" {
+		t.Errorf("formatFilterCondition with an empty operator map = %q, want empty", got)
+	}
+}
+
+func TestBuildReadableQueryString(t *testing.T) {
+	qc := newCounter(t)
+
+	t.Run("no filter", func(t *testing.T) {
+		got := qc.buildReadableQueryString("users", bson.M{})
+		if want := "db.users.countDocuments({})"; got != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
+	})
+
+	t.Run("nil filter", func(t *testing.T) {
+		got := qc.buildReadableQueryString("users", nil)
+		if want := "db.users.countDocuments({})"; got != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
+	})
+
+	t.Run("single condition", func(t *testing.T) {
+		got := qc.buildReadableQueryString("users", bson.M{"status": "active"})
+		if want := `db.users.countDocuments({status: "active"})`; got != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
+	})
+
+	t.Run("several conditions", func(t *testing.T) {
+		got := qc.buildReadableQueryString("users", bson.M{
+			"status": "active",
+			"count":  3,
+		})
+		// Map iteration order is unspecified, so check the parts rather than
+		// the exact string.
+		for _, part := range []string{`status: "active"`, "count: 3"} {
+			if !strings.Contains(got, part) {
+				t.Errorf("query %q is missing %q", got, part)
+			}
+		}
+		if !strings.HasPrefix(got, "db.users.countDocuments({") || !strings.HasSuffix(got, "})") {
+			t.Errorf("query %q is not wrapped correctly", got)
+		}
+	})
+}
+
+// TestBuildReadableQueryStringHidesUnrenderableFilters records a reporting
+// defect. A filter whose conditions all render as empty strings produces
+// "countDocuments({})", identical to the no-filter case, so the log line claims
+// an unfiltered count while the real query was filtered. The string is used in
+// operator-facing logs, which makes the two indistinguishable after the fact.
+func TestBuildReadableQueryStringHidesUnrenderableFilters(t *testing.T) {
+	qc := newCounter(t)
+
+	got := qc.buildReadableQueryString("users", bson.M{"created_at": bson.M{}})
+
+	if got != "db.users.countDocuments({})" {
+		t.Errorf("got %q; unrenderable conditions may now be surfaced, so assert "+
+			"the new rendering instead", got)
+	}
+}
+
+func TestNewQueryCounterWithYesterdaySupport(t *testing.T) {
+	logger := logrus.New()
+	logger.SetLevel(logrus.PanicLevel)
+
+	start := time.Date(2026, 8, 20, 0, 0, 0, 0, time.UTC)
+	end := time.Date(2026, 8, 21, 0, 0, 0, 0, time.UTC)
+
+	qc := NewQueryCounterWithYesterdaySupport(logger, start, end)
+	if qc == nil {
+		t.Fatal("NewQueryCounterWithYesterdaySupport returned nil")
+	}
+	// The plain constructor must not carry a range.
+	if plain := NewQueryCounter(logger); plain == nil {
+		t.Fatal("NewQueryCounter returned nil")
+	}
+}

--- a/pkg/utils/retry_test.go
+++ b/pkg/utils/retry_test.go
@@ -1,0 +1,114 @@
+package utils
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestRetrySucceedsImmediately(t *testing.T) {
+	calls := 0
+	start := time.Now()
+
+	err := Retry(5, 50*time.Millisecond, 2.0, func() error {
+		calls++
+		return nil
+	})
+
+	if err != nil {
+		t.Errorf("Retry returned %v, want nil", err)
+	}
+	if calls != 1 {
+		t.Errorf("the operation ran %d times, want 1", calls)
+	}
+	// No sleep happens when the first attempt succeeds.
+	if elapsed := time.Since(start); elapsed > 40*time.Millisecond {
+		t.Errorf("Retry took %v for an immediate success", elapsed)
+	}
+}
+
+func TestRetrySucceedsAfterFailures(t *testing.T) {
+	calls := 0
+
+	err := Retry(5, time.Millisecond, 2.0, func() error {
+		calls++
+		if calls < 3 {
+			return errors.New("not yet")
+		}
+		return nil
+	})
+
+	if err != nil {
+		t.Errorf("Retry returned %v, want nil", err)
+	}
+	if calls != 3 {
+		t.Errorf("the operation ran %d times, want 3", calls)
+	}
+}
+
+func TestRetryReturnsLastError(t *testing.T) {
+	last := errors.New("attempt 4")
+	calls := 0
+
+	err := Retry(4, time.Millisecond, 2.0, func() error {
+		calls++
+		if calls == 4 {
+			return last
+		}
+		return errors.New("earlier failure")
+	})
+
+	if !errors.Is(err, last) {
+		t.Errorf("Retry returned %v, want the final error", err)
+	}
+	if calls != 4 {
+		t.Errorf("the operation ran %d times, want 4", calls)
+	}
+}
+
+// TestRetrySleepsAfterTheFinalFailure records wasted time: the loop sleeps
+// after every failure including the last one, then falls out and returns. With
+// the settings the syncers use — Retry(5, 2s, 2.0) — the delays are 2+4+8+16+32
+// seconds, and that final 32-second sleep buys nothing. Connection failures are
+// therefore reported half a minute later than necessary.
+func TestRetrySleepsAfterTheFinalFailure(t *testing.T) {
+	const delay = 40 * time.Millisecond
+	start := time.Now()
+
+	_ = Retry(2, delay, 1.0, func() error { return errors.New("always fails") })
+
+	elapsed := time.Since(start)
+	// Two attempts, two sleeps. One sleep would be enough.
+	if elapsed < 2*delay {
+		t.Errorf("Retry took %v; the trailing sleep may have been removed, which "+
+			"would be an improvement", elapsed)
+	}
+}
+
+// TestRetryCannotBeCancelled records that Retry takes no context. A syncer
+// waiting inside it keeps sleeping through shutdown, and with the production
+// settings that is up to a minute after cancellation. cmd/sync waits ten
+// seconds for a graceful stop before exiting anyway.
+func TestRetryCannotBeCancelled(t *testing.T) {
+	// The signature is the evidence: there is no way to pass a context in.
+	var _ func(int, time.Duration, float64, func() error) error = Retry
+}
+
+func TestRetryZeroAttempts(t *testing.T) {
+	calls := 0
+
+	err := Retry(0, time.Millisecond, 2.0, func() error {
+		calls++
+		return errors.New("never runs")
+	})
+
+	// The loop body never executes, so the operation is not attempted and the
+	// caller gets a nil error for work that never happened.
+	if calls != 0 {
+		t.Errorf("the operation ran %d times, want 0", calls)
+	}
+	if err != nil {
+		t.Errorf("Retry returned %v; with zero attempts it reports success for "+
+			"an operation it never ran", err)
+	}
+}

--- a/pkg/utils/slack_test.go
+++ b/pkg/utils/slack_test.go
@@ -1,0 +1,256 @@
+package utils
+
+import (
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+// fakeConfig satisfies ConfigProvider.
+type fakeConfig struct {
+	webhook string
+	channel string
+}
+
+func (f fakeConfig) GetSlackWebhookURL() string { return f.webhook }
+func (f fakeConfig) GetSlackChannel() string    { return f.channel }
+
+// installScript writes an executable stub at ./cloudbuild.sh in a temporary
+// working directory, which is one of the three paths findCloudBuildScript
+// searches.
+func installScript(t *testing.T, body string) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	path := filepath.Join(dir, "cloudbuild.sh")
+	if err := os.WriteFile(path, []byte(body), 0o755); err != nil {
+		t.Fatalf("write script: %v", err)
+	}
+	return path
+}
+
+// chdirWithoutScript moves to an empty temporary directory so none of the
+// three search paths resolve.
+func chdirWithoutScript(t *testing.T) {
+	t.Helper()
+
+	t.Chdir(t.TempDir())
+}
+
+func TestFormatFileSize(t *testing.T) {
+	tests := []struct {
+		size int64
+		want string
+	}{
+		{0, "0 B"},
+		{1, "1 B"},
+		{1023, "1023 B"},
+		{1024, "1.0 KB"},
+		{1536, "1.5 KB"},
+		{1024 * 1024, "1.0 MB"},
+		{1024 * 1024 * 1024, "1.0 GB"},
+		{1024 * 1024 * 1024 * 1024, "1.0 TB"},
+		{5 * 1024 * 1024 * 1024 * 1024 * 1024, "5.0 PB"},
+	}
+
+	for _, tc := range tests {
+		if got := formatFileSize(tc.size); got != tc.want {
+			t.Errorf("formatFileSize(%d) = %q, want %q", tc.size, got, tc.want)
+		}
+	}
+}
+
+// A negative size is smaller than the unit, so it is reported in bytes rather
+// than rejected. No caller can produce one today (os.FileInfo.Size never
+// returns negative), so this pins the behaviour rather than reporting a bug.
+func TestFormatFileSizeOnANegativeSize(t *testing.T) {
+	if got := formatFileSize(-1); got != "-1 B" {
+		t.Errorf("formatFileSize(-1) = %q, want %q", got, "-1 B")
+	}
+}
+
+func TestFindCloudBuildScriptReturnsAnAbsolutePath(t *testing.T) {
+	want := installScript(t, "#!/bin/sh\nexit 0\n")
+
+	got := findCloudBuildScript()
+	if !filepath.IsAbs(got) {
+		t.Errorf("findCloudBuildScript() = %q, want an absolute path", got)
+	}
+	gotResolved, _ := filepath.EvalSymlinks(got)
+	wantResolved, _ := filepath.EvalSymlinks(want)
+	if gotResolved != wantResolved {
+		t.Errorf("findCloudBuildScript() = %q, want %q", gotResolved, wantResolved)
+	}
+}
+
+func TestFindCloudBuildScriptReturnsEmptyWhenAbsent(t *testing.T) {
+	chdirWithoutScript(t)
+
+	if got := findCloudBuildScript(); got != "" {
+		t.Errorf("findCloudBuildScript() = %q, want an empty string", got)
+	}
+}
+
+func TestNewSlackNotifierFromConfig(t *testing.T) {
+	installScript(t, "#!/bin/sh\nexit 0\n")
+
+	n := NewSlackNotifierFromConfig(fakeConfig{webhook: "https://hooks.example/x", channel: "#ops"}, quietLogger())
+
+	if n.webhookURL != "https://hooks.example/x" || n.channel != "#ops" {
+		t.Errorf("webhookURL = %q, channel = %q", n.webhookURL, n.channel)
+	}
+	if n.username != "sync-service" {
+		t.Errorf("username = %q, want sync-service", n.username)
+	}
+	if n.scriptPath == "" {
+		t.Error("scriptPath is empty despite the script being present")
+	}
+}
+
+func TestNewSlackNotifierFromConfigWithFieldLogger(t *testing.T) {
+	installScript(t, "#!/bin/sh\nexit 0\n")
+
+	src := logrus.New()
+	src.SetOutput(io.Discard)
+	src.SetLevel(logrus.WarnLevel)
+
+	n := NewSlackNotifierFromConfigWithFieldLogger(fakeConfig{webhook: "w", channel: "c"}, src)
+
+	if n.logger == nil {
+		t.Fatal("logger is nil")
+	}
+	if n.logger.GetLevel() != logrus.WarnLevel {
+		t.Errorf("level = %v, want %v", n.logger.GetLevel(), logrus.WarnLevel)
+	}
+}
+
+func TestIsConfigured(t *testing.T) {
+	installScript(t, "#!/bin/sh\nexit 0\n")
+
+	tests := []struct {
+		name    string
+		webhook string
+		channel string
+		want    bool
+	}{
+		{"both set", "https://hooks.example/x", "#ops", true},
+		{"no webhook", "", "#ops", false},
+		{"no channel", "https://hooks.example/x", "", false},
+		{"neither", "", "", false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			n := NewSlackNotifier(tc.webhook, tc.channel, quietLogger())
+			if got := n.IsConfigured(); got != tc.want {
+				t.Errorf("IsConfigured() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// Notifications are delivered by shelling out to cloudbuild.sh, which is
+// looked for at three hard-coded paths. In any deployment that does not ship
+// the script at one of them, IsConfigured returns false, SendNotification
+// returns nil, and the only trace is a Debug-level line. Every alert — sync
+// failure, backup failure — is silently dropped while the caller is told it
+// succeeded.
+func TestAMissingScriptSilentlyDropsEveryNotification(t *testing.T) {
+	chdirWithoutScript(t)
+
+	n := NewSlackNotifier("https://hooks.example/x", "#ops", quietLogger())
+
+	if n.IsConfigured() {
+		t.Fatal("IsConfigured() = true without the script — the transport appears to have changed")
+	}
+	if err := n.SendNotification(context.Background(), "the tokyo cluster is down", nil); err != nil {
+		t.Fatalf("SendNotification() = %v — a dropped notification appears to be reported now; assert the error instead", err)
+	}
+	if err := n.SendError(context.Background(), "replication", "target diverged"); err != nil {
+		t.Fatalf("SendError() = %v — a dropped notification appears to be reported now", err)
+	}
+}
+
+func TestSendNotificationInvokesTheScript(t *testing.T) {
+	out := filepath.Join(t.TempDir(), "args.txt")
+	installScript(t, "#!/bin/sh\nprintf '%s\\n' \"$@\" > "+out+"\nexit 0\n")
+
+	n := NewSlackNotifier("https://hooks.example/x", "#ops", quietLogger())
+	err := n.SendNotification(context.Background(), "hello", &SlackNotificationOptions{
+		AlertType:  SlackAlertDanger,
+		BranchName: "main",
+		Trigger:    "sync",
+		CommitURL:  "https://example/commit",
+	})
+	if err != nil {
+		t.Fatalf("SendNotification() = %v", err)
+	}
+
+	data, readErr := os.ReadFile(out)
+	if readErr != nil {
+		t.Fatalf("the script did not run: %v", readErr)
+	}
+	args := string(data)
+	for _, want := range []string{"-w", "https://hooks.example/x", "-c", "#ops", "-u", "sync-service",
+		"-m", "hello", "-a", "danger", "-b", "main", "-t", "sync", "-U", "https://example/commit"} {
+		if !strings.Contains(args, want) {
+			t.Errorf("argument %q was not passed (got: %q)", want, args)
+		}
+	}
+}
+
+func TestSendNotificationReportsAFailingScript(t *testing.T) {
+	installScript(t, "#!/bin/sh\necho boom >&2\nexit 3\n")
+
+	n := NewSlackNotifier("https://hooks.example/x", "#ops", quietLogger())
+
+	if err := n.SendNotification(context.Background(), "hello", nil); err == nil {
+		t.Error("SendNotification() = nil, want the script's non-zero exit")
+	}
+}
+
+func TestSendHelpersFormatTheirMessages(t *testing.T) {
+	out := filepath.Join(t.TempDir(), "args.txt")
+	installScript(t, "#!/bin/sh\nprintf '%s\\n' \"$@\" > "+out+"\nexit 0\n")
+
+	n := NewSlackNotifier("w", "c", quietLogger())
+
+	cases := []struct {
+		name string
+		call func() error
+		want string
+	}{
+		{"success", func() error { return n.SendSuccess(context.Background(), "backup", "12 tables") }, "✅ backup completed successfully"},
+		{"warning", func() error { return n.SendWarning(context.Background(), "replication", "lag 40s") }, "⚠️ replication"},
+		{"error", func() error { return n.SendError(context.Background(), "replication", "diverged") }, "❌ replication"},
+		{"sync status", func() error {
+			return n.SendSyncStatus(context.Background(), "MySQL", "tokyo", "osaka", 1200, 3*time.Second)
+		}, "🔄 MySQL Sync Completed"},
+		{"backup status", func() error {
+			return n.SendBackupStatus(context.Background(), "MongoDB", "orders", "orders.json", 3*1024*1024)
+		}, "Size: 3.0 MB"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := tc.call(); err != nil {
+				t.Fatalf("call: %v", err)
+			}
+			data, err := os.ReadFile(out)
+			if err != nil {
+				t.Fatalf("the script did not run: %v", err)
+			}
+			if !strings.Contains(string(data), tc.want) {
+				t.Errorf("message does not contain %q (got: %q)", tc.want, string(data))
+			}
+		})
+	}
+}

--- a/pkg/utils/time_utils_test.go
+++ b/pkg/utils/time_utils_test.go
@@ -1,0 +1,305 @@
+package utils
+
+import (
+	"reflect"
+	"regexp"
+	"testing"
+	"time"
+)
+
+// fixedDate is a Friday in August, chosen so that the month (08) and day (21)
+// are distinguishable from each other and from the year.
+var fixedDate = time.Date(2026, 8, 21, 13, 45, 30, 0, time.UTC)
+
+func TestReplaceDatePlaceholdersWithDate(t *testing.T) {
+	tests := []struct {
+		name    string
+		pattern string
+		want    string
+	}{
+		{"braced upper", "{YYYY}-{MM}-{DD}", "2026-08-21"},
+		{"braced lower", "{yyyy}/{mm}/{dd}", "2026/08/21"},
+		{"bare upper", "YYYYMMDD", "20260821"},
+		{"bare lower", "yyyymmdd", "20260821"},
+		{"mixed with prefix", "backup_{YYYY}{MM}{DD}.json", "backup_20260821.json"},
+		{"no placeholder", "orders.json", "orders.json"},
+		{"empty", "", ""},
+		{"month is zero padded", "{MM}", "08"},
+		{"day is zero padded", "{DD}", "21"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ReplaceDatePlaceholdersWithDate(tt.pattern, fixedDate); got != tt.want {
+				t.Errorf("ReplaceDatePlaceholdersWithDate(%q) = %q, want %q", tt.pattern, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestReplaceDatePlaceholdersCorruptsOrdinaryText records a defect with a wide
+// blast radius. After handling the braced forms, the function also replaces the
+// bare substrings YYYY, MM, DD, yyyy, mm and dd "for backward compatibility".
+// Those are two-letter sequences that occur in ordinary English words, so any
+// table or file name containing them is silently rewritten with digits.
+//
+// The one caller is processFileNamePattern in pkg/backup/executor.go, which
+// applies this to the user-supplied file name pattern. The table name itself is
+// appended afterwards and so survives, but any descriptive wording in the
+// pattern does not: `summary_YYYYMM.json` yields `su08ary_202608.json`, and
+// that is the name the backup is stored under in GCS.
+func TestReplaceDatePlaceholdersCorruptsOrdinaryText(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+		why   string
+	}{
+		{"summary", "su08ary", "mm -> 08"},
+		{"address", "a21ress", "dd -> 21"},
+		{"middleware", "mi21leware", "dd -> 21"},
+		{"comment", "co08ent", "mm -> 08"},
+		{"recommended", "reco08ended", "mm -> 08"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := ReplaceDatePlaceholdersWithDate(tt.input, fixedDate)
+
+			if got == tt.input {
+				t.Fatalf("ReplaceDatePlaceholdersWithDate(%q) is now left alone; the bare "+
+					"substring replacement may have been removed, so assert that instead", tt.input)
+			}
+			if got != tt.want {
+				t.Errorf("ReplaceDatePlaceholdersWithDate(%q) = %q, want %q (%s)",
+					tt.input, got, tt.want, tt.why)
+			}
+		})
+	}
+}
+
+// TestReplaceDatePlaceholdersMixesSuccessAndCorruption shows both behaviours in
+// one realistic pattern: the intended date suffix resolves correctly while the
+// table name in the same string is mangled.
+func TestReplaceDatePlaceholdersMixesSuccessAndCorruption(t *testing.T) {
+	const pattern = "order_summary_YYYYMM.json"
+
+	got := ReplaceDatePlaceholdersWithDate(pattern, fixedDate)
+
+	if want := "order_su08ary_202608.json"; got != want {
+		t.Errorf("ReplaceDatePlaceholdersWithDate(%q) = %q, want %q", pattern, got, want)
+	}
+}
+
+func TestReplaceDatePlaceholdersUsesCurrentDate(t *testing.T) {
+	// Only the shape is asserted, since the real clock is involved.
+	got := ReplaceDatePlaceholders("{YYYY}-{MM}-{DD}")
+
+	if !regexp.MustCompile(`^\d{4}-\d{2}-\d{2}$`).MatchString(got) {
+		t.Errorf("ReplaceDatePlaceholders = %q, want a YYYY-MM-DD shaped string", got)
+	}
+}
+
+func TestGetTodayDateString(t *testing.T) {
+	got := GetTodayDateString()
+
+	if !regexp.MustCompile(`^\d{4}-\d{2}-\d{2}$`).MatchString(got) {
+		t.Errorf("GetTodayDateString = %q, want a YYYY-MM-DD shaped string", got)
+	}
+}
+
+func TestParseDatabaseTimestamp(t *testing.T) {
+	got, err := ParseDatabaseTimestamp("2026-08-21 13:45:30")
+	if err != nil {
+		t.Fatalf("ParseDatabaseTimestamp returned %v", err)
+	}
+	if want := time.Date(2026, 8, 21, 13, 45, 30, 0, time.UTC); !got.Equal(want) {
+		t.Errorf("ParseDatabaseTimestamp = %v, want %v", got, want)
+	}
+
+	for _, bad := range []string{"2026-08-21", "21/08/2026 13:45:30", "", "not a time"} {
+		if _, err := ParseDatabaseTimestamp(bad); err == nil {
+			t.Errorf("ParseDatabaseTimestamp(%q) succeeded, want an error", bad)
+		}
+	}
+}
+
+func TestProcessTimeRangeQueryConvertsDaily(t *testing.T) {
+	query := map[string]interface{}{
+		"created_at": map[string]interface{}{
+			"type":        "daily",
+			"startOffset": float64(-1),
+			"endOffset":   float64(0),
+		},
+	}
+
+	got, err := ProcessTimeRangeQuery(query)
+	if err != nil {
+		t.Fatalf("ProcessTimeRangeQuery returned %v", err)
+	}
+
+	converted, ok := got["created_at"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("created_at is not a map: %#v", got["created_at"])
+	}
+	gte, ok := converted["$gte"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("$gte is missing or not a map: %#v", converted)
+	}
+	lt, ok := converted["$lt"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("$lt is missing or not a map: %#v", converted)
+	}
+
+	// Both bounds are extended JSON dates at UTC midnight-equivalents of JST
+	// day boundaries, which is 15:00:00 UTC on the preceding day.
+	for name, bound := range map[string]map[string]interface{}{"$gte": gte, "$lt": lt} {
+		s, ok := bound["$date"].(string)
+		if !ok {
+			t.Fatalf("%s has no $date string: %#v", name, bound)
+		}
+		parsed, err := time.Parse("2006-01-02T15:04:05.000Z", s)
+		if err != nil {
+			t.Fatalf("%s date %q does not parse: %v", name, s, err)
+		}
+		if parsed.Hour() != 15 || parsed.Minute() != 0 || parsed.Second() != 0 {
+			t.Errorf("%s = %q, want 15:00:00 UTC (JST midnight)", name, s)
+		}
+	}
+
+	startStr := gte["$date"].(string)
+	endStr := lt["$date"].(string)
+	start, _ := time.Parse("2006-01-02T15:04:05.000Z", startStr)
+	end, _ := time.Parse("2006-01-02T15:04:05.000Z", endStr)
+	if !start.Before(end) {
+		t.Errorf("start %q is not before end %q", startStr, endStr)
+	}
+	if got := end.Sub(start); got != 24*time.Hour {
+		t.Errorf("range spans %v, want 24h for offsets -1..0", got)
+	}
+}
+
+func TestProcessTimeRangeQueryPassesThroughNonRanges(t *testing.T) {
+	tests := []struct {
+		name  string
+		value interface{}
+	}{
+		{"scalar", "active"},
+		{"map without type", map[string]interface{}{"$gt": 5}},
+		{"non-string type", map[string]interface{}{"type": 42}},
+		// The comparison against "daily" is case-sensitive, so a capitalised
+		// type is forwarded verbatim and reaches MongoDB as a literal filter.
+		{"capitalised daily", map[string]interface{}{"type": "Daily", "startOffset": float64(-1), "endOffset": float64(0)}},
+		{"unknown type", map[string]interface{}{"type": "weekly", "startOffset": float64(-7), "endOffset": float64(0)}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ProcessTimeRangeQuery(map[string]interface{}{"field": tt.value})
+			if err != nil {
+				t.Fatalf("ProcessTimeRangeQuery returned %v", err)
+			}
+			if !reflect.DeepEqual(got["field"], tt.value) {
+				t.Errorf("field = %#v, want it passed through unchanged (%#v)", got["field"], tt.value)
+			}
+		})
+	}
+}
+
+// TestProcessTimeRangeQueryKeepsMalformedRangeVerbatim records a defect that
+// turns a configuration mistake into an empty backup. When a daily range fails
+// to convert — a missing offset, or offsets supplied as anything other than a
+// JSON number — the error is logged and the *original object* is kept as the
+// query value. MongoDB then receives `{type: "daily", startOffset: ...}` as a
+// literal equality filter, matches nothing, and the backup completes with an
+// empty file and no error anywhere.
+func TestProcessTimeRangeQueryKeepsMalformedRangeVerbatim(t *testing.T) {
+	malformed := []struct {
+		name  string
+		value map[string]interface{}
+	}{
+		{"missing endOffset", map[string]interface{}{"type": "daily", "startOffset": float64(-1)}},
+		{"missing both offsets", map[string]interface{}{"type": "daily"}},
+		{"offsets as strings", map[string]interface{}{"type": "daily", "startOffset": "-1", "endOffset": "0"}},
+		{"offsets as ints", map[string]interface{}{"type": "daily", "startOffset": -1, "endOffset": 0}},
+	}
+
+	for _, tt := range malformed {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ProcessTimeRangeQuery(map[string]interface{}{"created_at": tt.value})
+			if err != nil {
+				t.Fatalf("ProcessTimeRangeQuery returned %v", err)
+			}
+
+			kept, ok := got["created_at"].(map[string]interface{})
+			if !ok {
+				t.Fatalf("created_at is not a map: %#v", got["created_at"])
+			}
+			if _, converted := kept["$gte"]; converted {
+				t.Fatalf("the malformed range was converted; error handling may have " +
+					"changed, so assert the new behaviour instead")
+			}
+			if kept["type"] != "daily" {
+				t.Errorf("created_at = %#v, want the original object preserved verbatim", kept)
+			}
+		})
+	}
+}
+
+// TestProcessTimeRangeQueryNeverReturnsError records that the error return is
+// always nil: conversion failures are logged and swallowed inside the loop.
+// Callers cannot distinguish a converted query from a silently skipped one.
+func TestProcessTimeRangeQueryNeverReturnsError(t *testing.T) {
+	inputs := []map[string]interface{}{
+		nil,
+		{},
+		{"created_at": map[string]interface{}{"type": "daily"}},
+		{"created_at": map[string]interface{}{"type": "daily", "startOffset": "bad", "endOffset": "bad"}},
+	}
+
+	for _, in := range inputs {
+		if _, err := ProcessTimeRangeQuery(in); err != nil {
+			t.Errorf("ProcessTimeRangeQuery(%#v) returned %v; if it now reports "+
+				"failures, update this test and the callers", in, err)
+		}
+	}
+}
+
+func TestGetJSTTimeRange(t *testing.T) {
+	start, end, err := GetJSTTimeRange(-7, 0)
+	if err != nil {
+		t.Fatalf("GetJSTTimeRange returned %v", err)
+	}
+
+	// Both bounds sit at midnight in Asia/Tokyo.
+	for name, ts := range map[string]time.Time{"start": start, "end": end} {
+		if ts.Hour() != 0 || ts.Minute() != 0 || ts.Second() != 0 || ts.Nanosecond() != 0 {
+			t.Errorf("%s = %v, want midnight", name, ts)
+		}
+		if zone, offset := ts.Zone(); offset != 9*60*60 {
+			t.Errorf("%s zone = %s (%d s), want JST (+32400 s)", name, zone, offset)
+		}
+	}
+	if got := end.Sub(start); got != 7*24*time.Hour {
+		t.Errorf("range spans %v, want 168h for offsets -7..0", got)
+	}
+}
+
+func TestGetUTCTimeRangeMatchesJST(t *testing.T) {
+	startJST, endJST, err := GetJSTTimeRange(-1, 0)
+	if err != nil {
+		t.Fatalf("GetJSTTimeRange returned %v", err)
+	}
+	startUTC, endUTC, err := GetUTCTimeRange(-1, 0)
+	if err != nil {
+		t.Fatalf("GetUTCTimeRange returned %v", err)
+	}
+
+	if !startUTC.Equal(startJST) || !endUTC.Equal(endJST) {
+		t.Errorf("UTC range %v..%v is not the same instant as JST %v..%v",
+			startUTC, endUTC, startJST, endJST)
+	}
+	// JST midnight is 15:00 UTC on the previous day.
+	if startUTC.UTC().Hour() != 15 {
+		t.Errorf("start in UTC = %v, want 15:00", startUTC.UTC())
+	}
+}

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -1,0 +1,91 @@
+package utils
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestParseInt(t *testing.T) {
+	tests := []struct {
+		in      string
+		want    int
+		wantErr bool
+	}{
+		{"42", 42, false},
+		{"-7", -7, false},
+		{"0", 0, false},
+		{"", 0, true},
+		{"1.5", 0, true},
+		{"abc", 0, true},
+		{" 42", 0, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			got, err := ParseInt(tt.in)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("ParseInt(%q) succeeded with %d, want an error", tt.in, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ParseInt(%q) returned %v", tt.in, err)
+			}
+			if got != tt.want {
+				t.Errorf("ParseInt(%q) = %d, want %d", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetCurrentTime(t *testing.T) {
+	before := time.Now()
+	got := GetCurrentTime()
+	after := time.Now()
+
+	if got.Before(before) || got.After(after) {
+		t.Errorf("GetCurrentTime returned %v, outside [%v, %v]", got, before, after)
+	}
+}
+
+func TestUnzipDistFile(t *testing.T) {
+	if _, err := exec.LookPath("zip"); err != nil {
+		t.Skip("the zip command is unavailable")
+	}
+
+	work := t.TempDir()
+	payload := filepath.Join(work, "hello.txt")
+	if err := os.WriteFile(payload, []byte("contents"), 0o644); err != nil {
+		t.Fatalf("write payload: %v", err)
+	}
+	archive := filepath.Join(work, "dist.zip")
+	cmd := exec.Command("zip", "-j", archive, payload)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Skipf("could not build the archive: %v (%s)", err, out)
+	}
+
+	dest := filepath.Join(work, "out")
+	if err := UnzipDistFile(archive, dest); err != nil {
+		t.Fatalf("UnzipDistFile: %v", err)
+	}
+
+	got, err := os.ReadFile(filepath.Join(dest, "hello.txt"))
+	if err != nil {
+		t.Fatalf("read extracted file: %v", err)
+	}
+	if string(got) != "contents" {
+		t.Errorf("extracted %q, want %q", got, "contents")
+	}
+}
+
+func TestUnzipDistFileMissingArchive(t *testing.T) {
+	err := UnzipDistFile(filepath.Join(t.TempDir(), "absent.zip"), filepath.Join(t.TempDir(), "out"))
+
+	if err == nil {
+		t.Error("UnzipDistFile succeeded for a missing archive, want an error")
+	}
+}

--- a/test/harness/harness.go
+++ b/test/harness/harness.go
@@ -1,0 +1,143 @@
+// Package harness provides shared fixtures for the integration suite: endpoint
+// discovery, convergence polling, and sync task construction.
+//
+// Endpoints default to the stack in docker/docker-compose.test.yml and can be
+// overridden per engine with environment variables, so the same tests run
+// against a local stack or CI.
+package harness
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+)
+
+// Endpoint addresses. Every value is overridable so the suite is not tied to
+// one machine's port allocation.
+var (
+	MongoSource = env("SYNC_TEST_MONGO_SOURCE", "127.0.0.1:27117")
+	MongoTarget = env("SYNC_TEST_MONGO_TARGET", "127.0.0.1:27118")
+	MySQLSource = env("SYNC_TEST_MYSQL_SOURCE", "127.0.0.1:3306")
+	MySQLTarget = env("SYNC_TEST_MYSQL_TARGET", "127.0.0.1:3308")
+	RedisSource = env("SYNC_TEST_REDIS_SOURCE", "127.0.0.1:6479")
+	RedisTarget = env("SYNC_TEST_REDIS_TARGET", "127.0.0.1:6480")
+)
+
+func env(key, fallback string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return fallback
+}
+
+// SplitHostPort separates an endpoint into its parts, failing the test rather
+// than returning an error, since a malformed endpoint is a configuration
+// mistake and not a condition under test.
+func SplitHostPort(t *testing.T, endpoint string) (host, port string) {
+	t.Helper()
+
+	for i := len(endpoint) - 1; i >= 0; i-- {
+		if endpoint[i] == ':' {
+			return endpoint[:i], endpoint[i+1:]
+		}
+	}
+	t.Fatalf("endpoint %q has no port", endpoint)
+	return "", ""
+}
+
+// Eventually polls until cond returns nil or the deadline passes, then reports
+// the last error. It replaces the fixed sleeps the previous suite relied on:
+// a passing assertion returns as soon as the system converges, and a failing
+// one explains what it was still waiting for.
+func Eventually(t *testing.T, timeout time.Duration, cond func() error) {
+	t.Helper()
+
+	const interval = 100 * time.Millisecond
+	deadline := time.Now().Add(timeout)
+
+	var last error
+	for {
+		last = cond()
+		if last == nil {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("condition not met within %v: %v", timeout, last)
+		}
+		time.Sleep(interval)
+	}
+}
+
+// WaitFor polls until cond returns nil and reports whether it ever did. Use it
+// where the condition is expected *not* to hold — a defect being recorded — so
+// the test spends the full window only while the defect is present and returns
+// immediately once it is fixed. Eventually is the right call when the
+// condition is expected to hold; this one never fails the test by itself.
+func WaitFor(timeout time.Duration, cond func() error) bool {
+	const interval = 100 * time.Millisecond
+	deadline := time.Now().Add(timeout)
+
+	for {
+		if cond() == nil {
+			return true
+		}
+		if time.Now().After(deadline) {
+			return false
+		}
+		time.Sleep(interval)
+	}
+}
+
+// Consistently checks that cond keeps holding for the whole window. Use it to
+// assert that something does *not* happen, such as a document that must never
+// reach the target.
+func Consistently(t *testing.T, window time.Duration, cond func() error) {
+	t.Helper()
+
+	const interval = 100 * time.Millisecond
+	deadline := time.Now().Add(window)
+
+	for time.Now().Before(deadline) {
+		if err := cond(); err != nil {
+			t.Fatalf("condition stopped holding after the check began: %v", err)
+		}
+		time.Sleep(interval)
+	}
+}
+
+// RunSyncer starts a syncer in the background and returns a stop function that
+// cancels it and waits for the goroutine to unwind. Every test must call the
+// returned function, normally through t.Cleanup.
+func RunSyncer(t *testing.T, start func(context.Context)) (stop func()) {
+	t.Helper()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		start(ctx)
+	}()
+
+	var stopped bool
+	return func() {
+		if stopped {
+			return
+		}
+		stopped = true
+		cancel()
+		select {
+		case <-done:
+		case <-time.After(15 * time.Second):
+			t.Log("syncer did not stop within 15s of cancellation")
+		}
+	}
+}
+
+// UniqueName builds a collection or table name unique to one test run, so
+// tests can share a database without colliding and without a cleanup step
+// having to run before the next one starts.
+func UniqueName(prefix string) string {
+	return fmt.Sprintf("%s_%d", prefix, time.Now().UnixNano())
+}

--- a/test/harness/harness.go
+++ b/test/harness/harness.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 // Package harness provides shared fixtures for the integration suite: endpoint
 // discovery, convergence polling, and sync task construction.
 //


### PR DESCRIPTION
Closes #53.

`develop` has no test files — #54 deleted the legacy suite so it could be rebuilt. This is the rebuild: 467 tests written against a feature inventory rather than against the old suite.

Unit tests are hermetic. Anything needing a live database sits behind `//go:build integration`, including the shared harness in `test/harness`, so it stays out of the default build and out of the coverage report.

| Package | Statements covered |
|---|---:|
`pkg/state` | 100.0% |
`pkg/syncer/common` | 95.0% |
`pkg/config` | 83.3% |
`pkg/logger` | 64.3% |
`pkg/backup` | 52.3% |
`pkg/api` | 50.8% |
`pkg/syncer/security` | 44.4% |
`pkg/utils` | 41.3% |
`pkg/syncer/mongodb` | 14.3% |
`cmd/sync` | 11.1% |

Repository-wide that is 2,328 of 6,532 statements. **codecov reports 37.58%** — it counts lines rather than statements, so the two figures differ by construction; codecov's is the one on this PR.

Where a test pins behaviour that is wrong, its name and comment say so, so it fails loudly once the behaviour is fixed.

`go test -race -coverprofile=coverage.txt -covermode=atomic ./...` passes on 12 packages.
