### PR TITLE
feat(mongodb): export plain JSON so BigQuery can read it directly

### DIFF
--- a/pkg/backup/external_simple.go
+++ b/pkg/backup/external_simple.go
@@ -50,10 +50,10 @@ func (e *BackupExecutor) ExecuteExternalMongoBackup(ctx context.Context, config 
 
 	e.logMemoryUsage("AFTER_MONGOEXPORT")
 
-	// Step 2: External zip command
-	logrus.Infof("[BackupExecutor] 🗜️ Step 2: External zip compression")
-	if err := e.executeExternalZip(ctx, tempDir, outputPath, zipPath); err != nil {
-		return fmt.Errorf("external zip failed: %w", err)
+	// Step 2: External zip command, unless compression is explicitly disabled
+	uploadPath, zipped, err := e.compressForUpload(ctx, tempDir, outputPath, zipPath, config.CompressionType)
+	if err != nil {
+		return err
 	}
 
 	e.logMemoryUsage("AFTER_ZIP")
@@ -61,8 +61,8 @@ func (e *BackupExecutor) ExecuteExternalMongoBackup(ctx context.Context, config 
 	// Step 3: External gsutil upload (if GCS is configured)
 	if config.Destination.GCSPath != "" {
 		logrus.Infof("[BackupExecutor] ☁️ Step 3: External GCS upload")
-		gcsPath := fmt.Sprintf("%s/%s%s%s.zip", config.Destination.GCSPath, baseCollectionName, ZIPFilenameSeparator, dateStr)
-		if err := e.executeExternalGCSUpload(ctx, zipPath, gcsPath); err != nil {
+		gcsPath := fmt.Sprintf("%s/%s", config.Destination.GCSPath, filepath.Base(uploadPath))
+		if err := e.executeExternalGCSUpload(ctx, uploadPath, gcsPath); err != nil {
 			return fmt.Errorf("external GCS upload failed: %w", err)
 		}
 	}
@@ -76,10 +76,12 @@ func (e *BackupExecutor) ExecuteExternalMongoBackup(ctx context.Context, config 
 		logrus.Debugf("[BackupExecutor] 🗑️  Cleaned up JSON file: %s", outputPath)
 	}
 
-	if err := os.Remove(zipPath); err != nil {
-		logrus.Warnf("[BackupExecutor] Failed to remove ZIP file %s: %v", zipPath, err)
-	} else {
-		logrus.Debugf("[BackupExecutor] 🗑️  Cleaned up ZIP file: %s", zipPath)
+	if zipped {
+		if err := os.Remove(zipPath); err != nil {
+			logrus.Warnf("[BackupExecutor] Failed to remove ZIP file %s: %v", zipPath, err)
+		} else {
+			logrus.Debugf("[BackupExecutor] 🗑️  Cleaned up ZIP file: %s", zipPath)
+		}
 	}
 
 	logrus.Infof("[BackupExecutor] ✅ External backup completed for collection: %s", collection)
@@ -113,6 +115,26 @@ func (e *BackupExecutor) executeExternalMongoExport(ctx context.Context, connStr
 	}
 
 	return nil
+}
+
+// compressForUpload zips outputPath into zipPath and reports which file to
+// upload, unless the job asked for no compression. The MongoDB paths used to
+// zip regardless of what the job asked for, which left BigQuery unable to read
+// what landed in the bucket: it reads plain JSON, but not a ZIP archive.
+func (e *BackupExecutor) compressForUpload(
+	ctx context.Context, tempDir, outputPath, zipPath, compressionType string,
+) (uploadPath string, zipped bool, err error) {
+	if isCompressionDisabled(compressionType) {
+		logrus.Infof("[BackupExecutor] ⏭️  Step 2: Compression disabled, uploading %s as-is",
+			filepath.Base(outputPath))
+		return outputPath, false, nil
+	}
+
+	logrus.Infof("[BackupExecutor] 🗜️ Step 2: External zip compression")
+	if err := e.executeExternalZip(ctx, tempDir, outputPath, zipPath); err != nil {
+		return "", false, fmt.Errorf("external zip failed: %w", err)
+	}
+	return zipPath, true, nil
 }
 
 // executeExternalZip executes external zip command
@@ -191,19 +213,18 @@ func (e *BackupExecutor) executeExternalMongoExportSimple(ctx context.Context, c
 
 	e.logMemoryUsage("AFTER_EXTERNAL_EXPORT")
 
-	// Step 2: External zip command
-	logrus.Infof("[BackupExecutor] 🗜️ Step 2: External zip compression")
-	if err := e.executeExternalZip(ctx, tempDir, outputPath, zipPath); err != nil {
-		return fmt.Errorf("external zip failed: %w", err)
+	// Step 2: External zip command, unless compression is explicitly disabled
+	uploadPath, zipped, err := e.compressForUpload(ctx, tempDir, outputPath, zipPath, config.CompressionType)
+	if err != nil {
+		return err
 	}
 
 	e.logMemoryUsage("AFTER_EXTERNAL_ZIP")
 
 	// Step 3: External GCS upload
-	zipFileName := fmt.Sprintf("%s%s%s.zip", baseCollectionName, ZIPFilenameSeparator, dateStr)
-	gcsPath := fmt.Sprintf("%s/%s", config.Destination.GCSPath, zipFileName)
+	gcsPath := fmt.Sprintf("%s/%s", config.Destination.GCSPath, filepath.Base(uploadPath))
 	logrus.Infof("[BackupExecutor] ☁️ Step 3: External GCS upload")
-	if err := e.executeExternalGCSUpload(ctx, zipPath, gcsPath); err != nil {
+	if err := e.executeExternalGCSUpload(ctx, uploadPath, gcsPath); err != nil {
 		return fmt.Errorf("external GCS upload failed: %w", err)
 	}
 
@@ -216,10 +237,12 @@ func (e *BackupExecutor) executeExternalMongoExportSimple(ctx context.Context, c
 		logrus.Debugf("[BackupExecutor] 🗑️  Cleaned up JSON file: %s", outputPath)
 	}
 
-	if err := os.Remove(zipPath); err != nil {
-		logrus.Warnf("[BackupExecutor] Failed to remove ZIP file %s: %v", zipPath, err)
-	} else {
-		logrus.Debugf("[BackupExecutor] 🗑️  Cleaned up ZIP file: %s", zipPath)
+	if zipped {
+		if err := os.Remove(zipPath); err != nil {
+			logrus.Warnf("[BackupExecutor] Failed to remove ZIP file %s: %v", zipPath, err)
+		} else {
+			logrus.Debugf("[BackupExecutor] 🗑️  Cleaned up ZIP file: %s", zipPath)
+		}
 	}
 
 	logrus.Infof("[BackupExecutor] ✅ COMPLETE external backup workflow completed for collection: %s", collection)
@@ -353,18 +376,18 @@ func (e *BackupExecutor) exportMongoDBMergedTables(ctx context.Context, connStr,
 
 	e.logMemoryUsage("AFTER_MERGE")
 
-	// Step 2: External zip command
-	logrus.Infof("[BackupExecutor] 🗜️ Step 2: External zip compression")
-	if err := e.executeExternalZip(ctx, tempDir, mergedJsonPath, zipPath); err != nil {
-		return fmt.Errorf("external zip failed: %w", err)
+	// Step 2: External zip command, unless compression is explicitly disabled
+	uploadPath, zipped, err := e.compressForUpload(ctx, tempDir, mergedJsonPath, zipPath, config.CompressionType)
+	if err != nil {
+		return err
 	}
 
 	e.logMemoryUsage("AFTER_EXTERNAL_ZIP")
 
 	// Step 3: External GCS upload
-	gcsPath := fmt.Sprintf("%s/%s", config.Destination.GCSPath, zipFileName)
+	gcsPath := fmt.Sprintf("%s/%s", config.Destination.GCSPath, filepath.Base(uploadPath))
 	logrus.Infof("[BackupExecutor] ☁️ Step 3: External GCS upload")
-	if err := e.executeExternalGCSUpload(ctx, zipPath, gcsPath); err != nil {
+	if err := e.executeExternalGCSUpload(ctx, uploadPath, gcsPath); err != nil {
 		return fmt.Errorf("external GCS upload failed: %w", err)
 	}
 
@@ -377,10 +400,12 @@ func (e *BackupExecutor) exportMongoDBMergedTables(ctx context.Context, connStr,
 		logrus.Debugf("[BackupExecutor] 🗑️  Cleaned up merged file: %s", mergedJsonPath)
 	}
 
-	if err := os.Remove(zipPath); err != nil {
-		logrus.Warnf("[BackupExecutor] Failed to remove ZIP file %s: %v", zipPath, err)
-	} else {
-		logrus.Debugf("[BackupExecutor] 🗑️  Cleaned up ZIP file: %s", zipPath)
+	if zipped {
+		if err := os.Remove(zipPath); err != nil {
+			logrus.Warnf("[BackupExecutor] Failed to remove ZIP file %s: %v", zipPath, err)
+		} else {
+			logrus.Debugf("[BackupExecutor] 🗑️  Cleaned up ZIP file: %s", zipPath)
+		}
 	}
 
 	logrus.Infof("[BackupExecutor] ✅ Multi-table merge backup completed successfully for %d tables", len(tables))


### PR DESCRIPTION

MongoDB backups can now be exported as plain JSON. Until now every MongoDB job produced a `.zip`, whatever its `compressionType` said.

## Why

BigQuery reads plain JSON and gzip, but not ZIP. With only ZIP coming out, a MongoDB collection could not be served through a BigQuery external table at all. Setting a job's `compressionType` to `none` now lands a `.json` in GCS that an external table reads directly, the same way the MySQL jobs already produce CSV.

## How

`compressForUpload` makes the call, mirroring what the MySQL paths already do via `isCompressionDisabled`. It covers all three MongoDB export paths — single collection, query/fields export, and merged tables — and cleanup only removes the ZIP when one was created.

Note the filename separator differs by format: `Collection_2026-08-30.json` versus `Collection-2026-08-30.zip`.

## No impact on existing tasks

`isCompressionDisabled` matches only a literal `none`. All 9 MongoDB tasks in production are `zip`, so every one of them takes the unchanged branch: same `executeExternalZip` call, same uploaded file, same GCS object name.

Targets `main` rather than `develop` because this is an urgent fix for production.

## Testing

`go build ./...` and `go vet ./pkg/backup/` pass. No unit tests added — `pkg/backup` has no test files on `main`.